### PR TITLE
Make the lexer much more flexible.

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -58,6 +58,8 @@ fn hifi(s: &[u8]) {
     use hifijson::token::Lex;
     let mut lexer = hifijson::SliceLexer::new(s);
     //lexer.exactly_one(hifijson::ignore::parse).unwrap();
-    lexer.exactly_one(hifijson::value::parse_unbounded).unwrap();
+    lexer
+        .exactly_one(Lex::ws_token, hifijson::value::parse_unbounded)
+        .unwrap();
     //hifijson::serde::exactly_one::<serde_json::Value, _>(&mut lexer).unwrap();
 }

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -1,14 +1,15 @@
 use hifijson::*;
 
 /// Count the number of parsed values.
-fn count(token: Token, lexer: &mut impl Lex) -> Result<usize, hifijson::Error> {
+fn count<L: Lex>(token: Token, lexer: &mut L) -> Result<usize, hifijson::Error> {
     match token {
-        Token::Null | Token::True | Token::False => Ok(1),
-        Token::DigitOrMinus => Ok(lexer.num_ignore().map(|_| 1)?),
+        Token::Letter => Ok(lexer.null_or_bool().map(|_| 1).ok_or(Expect::Value)?),
+        Token::Digit => Ok(lexer.num_ignore().map(|_| 1)?),
+        Token::Minus => count(Token::Digit, lexer),
         Token::Quote => Ok(lexer.str_ignore().map(|_| 1)?),
         Token::LSquare => {
             let mut sum = 1;
-            lexer.seq(Token::RSquare, |token, lexer| {
+            lexer.seq(Token::RSquare, L::ws_token, |token, lexer| {
                 sum += count(token, lexer)?;
                 Ok::<_, hifijson::Error>(())
             })?;
@@ -16,20 +17,22 @@ fn count(token: Token, lexer: &mut impl Lex) -> Result<usize, hifijson::Error> {
         }
         Token::LCurly => {
             let mut sum = 1;
-            lexer.seq(Token::RCurly, |token, lexer| {
-                lexer.str_colon(token, |lexer| lexer.str_ignore().map_err(Error::Str))?;
+            lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
+                lexer.str_colon(token, L::ws_token, |lexer| {
+                    lexer.str_ignore().map_err(Error::Str)
+                })?;
                 sum += count(lexer.ws_token().ok_or(Expect::Value)?, lexer)?;
                 Ok::<_, hifijson::Error>(())
             })?;
             Ok(sum)
         }
 
-        _ => Err(hifijson::Expect::Value)?,
+        _ => Err(Expect::Value)?,
     }
 }
 
-fn process(mut lexer: impl Lex) -> Result<usize, hifijson::Error> {
-    lexer.exactly_one(|token, lexer| count(token, lexer))
+fn process<L: Lex>(mut lexer: L) -> Result<usize, hifijson::Error> {
+    lexer.exactly_one(L::ws_token, |token, lexer| count(token, lexer))
 }
 
 fn main() {

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -5,12 +5,14 @@ use crate::{Error, Expect, Lex, Token};
 /// Parse and discard a value.
 pub fn parse<L: Lex>(token: Token, lexer: &mut L) -> Result<(), Error> {
     match token {
-        Token::Null | Token::True | Token::False => Ok(()),
-        Token::DigitOrMinus => Ok(lexer.num_ignore().map(|_| ())?),
+        Token::Letter => Ok(lexer.null_or_bool().map(|_| ()).ok_or(Expect::Value)?),
+        Token::Digit | Token::Minus => Ok(lexer.num_ignore().map(|_| ())?),
         Token::Quote => Ok(lexer.str_ignore()?),
-        Token::LSquare => lexer.seq(Token::RSquare, parse),
-        Token::LCurly => lexer.seq(Token::RCurly, |token, lexer| {
-            lexer.str_colon(token, |lexer| lexer.str_ignore().map_err(Error::Str))?;
+        Token::LSquare => lexer.seq(Token::RSquare, L::ws_token, parse),
+        Token::LCurly => lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
+            lexer.str_colon(token, L::ws_token, |lexer| {
+                lexer.str_ignore().map_err(Error::Str)
+            })?;
             parse(lexer.ws_token().ok_or(Expect::Value)?, lexer)
         }),
         _ => Err(Expect::Value)?,

--- a/src/token.rs
+++ b/src/token.rs
@@ -34,12 +34,8 @@ impl core::fmt::Display for Expect {
 /// JSON lexer token.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Token {
-    /// `null`
-    Null,
-    /// `true`
-    True,
-    /// `false`
-    False,
+    /// ASCII letter
+    Letter,
     /// `,`
     Comma,
     /// `:`
@@ -54,33 +50,38 @@ pub enum Token {
     RCurly,
     /// `"`
     Quote,
-    /// a digit (0-9) or a minus (`-`)
-    DigitOrMinus,
+    /// `-`
+    Minus,
+    /// `0`--`9`
+    Digit,
     /// anything else
     Error,
 }
 
 impl core::fmt::Display for Token {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        use Token::*;
-        match self {
-            Null => "null".fmt(f),
-            True => "true".fmt(f),
-            False => "false".fmt(f),
-            Comma => ",".fmt(f),
-            Colon => ":".fmt(f),
-            LSquare => "[".fmt(f),
-            RSquare => "]".fmt(f),
-            LCurly => "{".fmt(f),
-            RCurly => "}".fmt(f),
-            Quote => '"'.fmt(f),
-            DigitOrMinus => "number".fmt(f),
-            Error => "unknown token".fmt(f),
-        }
+        self.as_str().fmt(f)
     }
 }
 
 impl Token {
+    fn as_str(&self) -> &'static str {
+        use Token::*;
+        match self {
+            Comma => ",",
+            Colon => ":",
+            LSquare => "[",
+            RSquare => "]",
+            LCurly => "{",
+            RCurly => "}",
+            Quote => "\"",
+            Minus => "-",
+            Letter => "letter",
+            Digit => "digit",
+            Error => "unknown token",
+        }
+    }
+
     /// Return `Ok(())` if `self` equals `token`, else return `Err(err)`.
     pub fn equals_or<E>(&self, token: Token, err: E) -> Result<(), E> {
         if *self == token {
@@ -95,39 +96,39 @@ impl Token {
 pub trait Lex: crate::Read {
     /// Skip input until the earliest non-whitespace character.
     fn eat_whitespace(&mut self) {
-        self.skip_next_until(|c| !matches!(c, b' ' | b'\t' | b'\r' | b'\n'))
+        self.skip_until(|c| !matches!(c, b' ' | b'\t' | b'\r' | b'\n'))
     }
 
     /// Skip potential whitespace and return the following token if there is some.
     fn ws_token(&mut self) -> Option<Token> {
         self.eat_whitespace();
-        Some(self.token(*self.peek_next()?))
+        self.peek_next().map(|next| self.token(next))
     }
 
-    /// Return `out` if the input matches `s`, otherwise return an error.
-    fn exact<const N: usize>(&mut self, s: [u8; N], out: Token) -> Token {
+    /// Parse a JSON token starting with a letter.
+    fn null_or_bool(&mut self) -> Option<Option<bool>> {
         // we are calling this function without having advanced before
-        self.take_next();
-        if self.strip_prefix(s) {
-            out
-        } else {
-            Token::Error
-        }
+        Some(match self.take_next() {
+            Some(b'n') if self.strip_prefix(b"ull") => None,
+            Some(b't') if self.strip_prefix(b"rue") => Some(true),
+            Some(b'f') if self.strip_prefix(b"alse") => Some(false),
+            _ => return None,
+        })
     }
 
-    /// Convert a character to a token, such as '`:`' to `Token::Colon`.
+    /// Convert a character to a token, such as '`:`' to [`Token::Colon`].
     ///
-    /// When the token consists of several characters, such as
-    /// `null`, `true`, or `false`,
-    /// also consume the following characters.
+    /// Only when the token consists of a single character that can be
+    /// reconstructed losslessly from the token, such as `[` or `:`,
+    /// then the current character is consumed.
+    /// For all other tokens, like [`Token::Letter`], the character is preserved.
     fn token(&mut self, c: u8) -> Token {
         let token = match c {
-            // it is important to `return` here in order not to read a byte,
+            // it is important to `return` here in order not to take the next byte,
             // like we do for the regular, single-character tokens
-            b'n' => return self.exact([b'u', b'l', b'l'], Token::Null),
-            b't' => return self.exact([b'r', b'u', b'e'], Token::True),
-            b'f' => return self.exact([b'a', b'l', b's', b'e'], Token::False),
-            b'0'..=b'9' | b'-' => return Token::DigitOrMinus,
+            b'a'..=b'z' | b'A'..=b'Z' => return Token::Letter,
+            b'0'..=b'9' => return Token::Digit,
+            b'-' => Token::Minus,
             b'"' => Token::Quote,
             b'[' => Token::LSquare,
             b']' => Token::RSquare,
@@ -135,43 +136,45 @@ pub trait Lex: crate::Read {
             b'}' => Token::RCurly,
             b',' => Token::Comma,
             b':' => Token::Colon,
-            _ => Token::Error,
+            _ => return Token::Error,
         };
         self.take_next();
         token
     }
 
     /// Parse a string with given function, followed by a colon.
-    fn str_colon<T, E: From<Expect>, F>(&mut self, token: Token, f: F) -> Result<T, E>
+    fn str_colon<T, E: From<Expect>, TF, F>(&mut self, token: Token, tf: TF, f: F) -> Result<T, E>
     where
+        TF: FnOnce(&mut Self) -> Option<Token>,
         F: FnOnce(&mut Self) -> Result<T, E>,
     {
         token.equals_or(Token::Quote, Expect::String)?;
         let key = f(self)?;
 
-        let colon = self.ws_token().filter(|t| *t == Token::Colon);
+        let colon = tf(self).filter(|t| *t == Token::Colon);
         colon.ok_or(Expect::Colon)?;
 
         Ok(key)
     }
 
     /// Execute `f` for every item in the comma-separated sequence until `end`.
-    fn seq<E: From<Expect>, F>(&mut self, end: Token, mut f: F) -> Result<(), E>
+    fn seq<E: From<Expect>, TF, F>(&mut self, end: Token, mut tf: TF, mut f: F) -> Result<(), E>
     where
+        TF: FnMut(&mut Self) -> Option<Token>,
         F: FnMut(Token, &mut Self) -> Result<(), E>,
     {
-        let mut token = self.ws_token().ok_or(Expect::ValueOrEnd)?;
+        let mut token = tf(self).ok_or(Expect::ValueOrEnd)?;
         if token == end {
             return Ok(());
         };
 
         loop {
             f(token, self)?;
-            token = self.ws_token().ok_or(Expect::CommaOrEnd)?;
+            token = tf(self).ok_or(Expect::CommaOrEnd)?;
             if token == end {
                 return Ok(());
             } else if token == Token::Comma {
-                token = self.ws_token().ok_or(Expect::Value)?;
+                token = tf(self).ok_or(Expect::Value)?;
             } else {
                 return Err(Expect::CommaOrEnd)?;
             }
@@ -179,11 +182,12 @@ pub trait Lex: crate::Read {
     }
 
     /// Parse once using given function and assure that the function has consumed all tokens.
-    fn exactly_one<T, E: From<Expect>, F>(&mut self, f: F) -> Result<T, E>
+    fn exactly_one<T, E: From<Expect>, TF, F>(&mut self, mut tf: TF, f: F) -> Result<T, E>
     where
+        TF: FnMut(&mut Self) -> Option<Token>,
         F: FnOnce(Token, &mut Self) -> Result<T, E>,
     {
-        let token = self.ws_token().ok_or(Expect::Value)?;
+        let token = tf(self).ok_or(Expect::Value)?;
         let v = f(token, self)?;
         self.eat_whitespace();
         match self.peek_next() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,13 +13,37 @@ pub enum Value<Num, Str> {
     /// `true` or `false`
     Bool(bool),
     /// string representation of a number with positional information
-    Number((Num, num::Parts)),
+    Number(Sign, (Num, num::Parts)),
     /// string
     String(Str),
     /// array
     Array(Vec<Self>),
     /// mapping from strings to values
     Object(Vec<(Str, Self)>),
+}
+
+/// Sign of a number.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Sign {
+    /// positive
+    Pos,
+    /// negative
+    Neg,
+}
+
+impl Sign {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Sign::Pos => "",
+            Sign::Neg => "-",
+        }
+    }
+}
+
+impl fmt::Display for Sign {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
 }
 
 impl<NumL: PartialEq<NumR>, NumR, StrL: PartialEq<StrR>, StrR> PartialEq<Value<NumR, StrR>>
@@ -30,7 +54,7 @@ impl<NumL: PartialEq<NumR>, NumR, StrL: PartialEq<StrR>, StrR> PartialEq<Value<N
         match (self, other) {
             (Null, Null) => true,
             (Bool(l), Bool(r)) => l == r,
-            (Number((nl, pl)), Number((nr, pr))) => nl == nr && pl == pr,
+            (Number(sl, (nl, pl)), Number(sr, (nr, pr))) => sl == sr && nl == nr && pl == pr,
             (String(l), String(r)) => l == r,
             (Array(l), Array(r)) => l == r,
             (Object(l), Object(r)) => {
@@ -48,7 +72,7 @@ impl<Num: Deref<Target = str>, Str: Deref<Target = str>> fmt::Display for Value<
         match self {
             Null => "null".fmt(f),
             Bool(b) => b.fmt(f),
-            Number((n, _)) => n.fmt(f),
+            Number(sign, (n, _)) => write!(f, "{sign}{}", &**n),
             String(s) => str::Display::new(&**s).fmt(f),
             Array(a) => {
                 "[".fmt(f)?;
@@ -76,15 +100,15 @@ fn parse<L: LexAlloc>(
     lexer: &mut L,
     f: impl Fn(Token, &mut L) -> Result<Value<L::Num, L::Str>, Error>,
 ) -> Result<Value<L::Num, L::Str>, Error> {
+    let nob = |o: Option<bool>| o.map(Value::Bool).unwrap_or(Value::Null);
     match token {
-        Token::Null => Ok(Value::Null),
-        Token::True => Ok(Value::Bool(true)),
-        Token::False => Ok(Value::Bool(false)),
-        Token::DigitOrMinus => Ok(Value::Number(lexer.num_string()?)),
+        Token::Letter => Ok(lexer.null_or_bool().map(nob).ok_or(token::Expect::Value)?),
+        Token::Minus => Ok(Value::Number(Sign::Neg, lexer.num_string()?)),
+        Token::Digit => Ok(Value::Number(Sign::Pos, lexer.num_string()?)),
         Token::Quote => Ok(Value::String(lexer.str_string()?)),
         Token::LSquare => Ok(Value::Array({
             let mut arr = Vec::new();
-            lexer.seq(Token::RSquare, |token, lexer| {
+            lexer.seq(Token::RSquare, L::ws_token, |token, lexer| {
                 arr.push(f(token, lexer)?);
                 Ok::<_, Error>(())
             })?;
@@ -92,8 +116,10 @@ fn parse<L: LexAlloc>(
         })),
         Token::LCurly => Ok(Value::Object({
             let mut obj = Vec::new();
-            lexer.seq(Token::RCurly, |token, lexer| {
-                let key = lexer.str_colon(token, |lexer| lexer.str_string().map_err(Error::Str))?;
+            lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
+                let key = lexer.str_colon(token, L::ws_token, |lexer| {
+                    lexer.str_string().map_err(Error::Str)
+                })?;
                 let value = f(lexer.ws_token().ok_or(token::Expect::Value)?, lexer)?;
                 obj.push((key, value));
                 Ok::<_, Error>(())

--- a/src/write.rs
+++ b/src/write.rs
@@ -25,14 +25,13 @@ impl<E, I: Iterator<Item = Result<u8, E>>> Write for crate::IterLexer<E, I> {
     fn write_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(u8) -> bool) {
         use crate::Read;
         bytes.clear();
-        while let Some(c) = self.read() {
+        while let Some(c) = self.peek_next() {
             if stop(c) {
-                self.last = Some(c);
                 return;
             } else {
+                self.take_next();
                 bytes.push(c)
             }
         }
-        self.last = None
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,20 +1,24 @@
 use core::num::NonZeroUsize;
 use hifijson::token::{Lex, Token};
-use hifijson::value::{self, Value};
+use hifijson::value::{self, Sign, Value};
 use hifijson::{escape, ignore, num, str, Error, Expect, IterLexer, LexAlloc, SliceLexer};
 
-fn bol<Num, Str>(b: bool) -> Value<Num, Str> {
+fn boole<Num, Str>(b: bool) -> Value<Num, Str> {
     Value::Bool(b)
 }
 
-fn num<Num, Str>(n: Num, dot: Option<usize>, exp: Option<usize>) -> Value<Num, Str> {
+fn num<Num, Str>(sg: Sign, n: Num, dot: Option<usize>, exp: Option<usize>) -> Value<Num, Str> {
     let dot = dot.map(|i| NonZeroUsize::new(i).unwrap());
     let exp = exp.map(|i| NonZeroUsize::new(i).unwrap());
-    Value::Number((n, hifijson::num::Parts { dot, exp }))
+    Value::Number(sg, (n, num::Parts { dot, exp }))
 }
 
-fn int<Num, Str>(i: Num) -> Value<Num, Str> {
-    num(i, None, None)
+fn int<Num, Str>(sg: Sign, i: Num) -> Value<Num, Str> {
+    num(sg, i, None, None)
+}
+
+fn nat<Num, Str>(i: Num) -> Value<Num, Str> {
+    int(Sign::Pos, i)
 }
 
 fn arr<Num, Str, const N: usize>(v: [Value<Num, Str>; N]) -> Value<Num, Str> {
@@ -30,33 +34,35 @@ fn iter_of_slice(slice: &[u8]) -> impl Iterator<Item = Result<u8, ()>> + '_ {
 }
 
 fn parses_to(slice: &[u8], v: Value<&str, &str>) -> Result<(), Error> {
-    SliceLexer::new(slice).exactly_one(ignore::parse)?;
-    IterLexer::new(iter_of_slice(slice)).exactly_one(ignore::parse)?;
+    SliceLexer::new(slice).exactly_one(Lex::ws_token, ignore::parse)?;
+    IterLexer::new(iter_of_slice(slice)).exactly_one(Lex::ws_token, ignore::parse)?;
 
-    let parsed = SliceLexer::new(slice).exactly_one(value::parse_unbounded)?;
+    let parsed = SliceLexer::new(slice).exactly_one(Lex::ws_token, value::parse_unbounded)?;
     assert_eq!(parsed, v);
 
-    let parsed = IterLexer::new(iter_of_slice(slice)).exactly_one(value::parse_unbounded)?;
+    let parsed =
+        IterLexer::new(iter_of_slice(slice)).exactly_one(Lex::ws_token, value::parse_unbounded)?;
     assert_eq!(parsed, v);
 
     Ok(())
 }
 
 fn parses_to_binary_string(slice: &[u8], v: &[u8]) -> Result<(), Error> {
-    SliceLexer::new(slice).exactly_one(ignore::parse)?;
-    IterLexer::new(iter_of_slice(slice)).exactly_one(ignore::parse)?;
+    SliceLexer::new(slice).exactly_one(Lex::ws_token, ignore::parse)?;
+    IterLexer::new(iter_of_slice(slice)).exactly_one(Lex::ws_token, ignore::parse)?;
 
-    let parsed = SliceLexer::new(slice).exactly_one(parse_binary_string)?;
+    let parsed = SliceLexer::new(slice).exactly_one(Lex::ws_token, parse_binary_string)?;
     assert_eq!(parsed, v);
 
-    let parsed = IterLexer::new(iter_of_slice(slice)).exactly_one(parse_binary_string)?;
+    let parsed =
+        IterLexer::new(iter_of_slice(slice)).exactly_one(Lex::ws_token, parse_binary_string)?;
     assert_eq!(parsed, v);
 
     Ok(())
 }
 
 fn parse_binary_string<L: LexAlloc>(token: Token, lexer: &mut L) -> Result<Vec<u8>, Error> {
-    if token != hifijson::Token::Quote {
+    if token != Token::Quote {
         Err(Error::Token(Expect::String))?
     }
     let on_string = |bytes: &mut L::Bytes, out: &mut Vec<u8>| {
@@ -64,27 +70,30 @@ fn parse_binary_string<L: LexAlloc>(token: Token, lexer: &mut L) -> Result<Vec<u
         Ok(())
     };
     lexer.str_fold(Vec::new(), on_string, |lexer, escape, out| {
-        let c = lexer.escape_char(escape).map_err(str::Error::Escape)?;
-        out.extend_from_slice(c.encode_utf8(&mut [0; 4]).as_bytes());
+        match lexer.escape_char(escape).map_err(str::Error::Escape)? {
+            escape::Hex::Unicode(u) => out.extend(u.encode_utf8(&mut [0; 4]).as_bytes()),
+            escape::Hex::Byte(b) => out.push(b),
+        }
         Ok(())
     })
 }
 
 fn fails_with(slice: &[u8], e: Error) {
-    let parsed = SliceLexer::new(slice).exactly_one(ignore::parse);
+    let parsed = SliceLexer::new(slice).exactly_one(Lex::ws_token, ignore::parse);
     assert_eq!(parsed.unwrap_err(), e);
 
-    let parsed = IterLexer::new(iter_of_slice(slice)).exactly_one(ignore::parse);
+    let parsed = IterLexer::new(iter_of_slice(slice)).exactly_one(Lex::ws_token, ignore::parse);
     assert_eq!(parsed.unwrap_err(), e);
 
     parse_fails_with(slice, e)
 }
 
 fn parse_fails_with(slice: &[u8], e: Error) {
-    let parsed = SliceLexer::new(slice).exactly_one(value::parse_unbounded);
+    let parsed = SliceLexer::new(slice).exactly_one(Lex::ws_token, value::parse_unbounded);
     assert_eq!(parsed.unwrap_err(), e);
 
-    let parsed = IterLexer::new(iter_of_slice(slice)).exactly_one(value::parse_unbounded);
+    let parsed =
+        IterLexer::new(iter_of_slice(slice)).exactly_one(Lex::ws_token, value::parse_unbounded);
     assert_eq!(parsed.unwrap_err(), e);
 }
 
@@ -106,17 +115,19 @@ fn basic() -> Result<(), Error> {
 
 #[test]
 fn numbers() -> Result<(), Error> {
-    parses_to(b"0", num("0", None, None))?;
-    parses_to(b"42", num("42", None, None))?;
-    parses_to(b"-0", num("-0", None, None))?;
-    parses_to(b"-42", num("-42", None, None))?;
+    use Sign::{Neg, Pos};
+    parses_to(b"0", nat("0"))?;
+    parses_to(b"42", nat("42"))?;
+    parses_to(b"-0", int(Neg, "0"))?;
+    parses_to(b"-42", int(Neg, "42"))?;
 
-    parses_to(b"3.14", num("3.14", Some(1), None))?;
+    parses_to(b"3.14", num(Pos, "3.14", Some(1), None))?;
 
     // speed of light in m/s
-    parses_to(b"299e6", num("299e6", None, Some(3)))?;
+    parses_to(b"299e6", num(Pos, "299e6", None, Some(3)))?;
     // now a bit more precise
-    parses_to(b"299.792e6", num("299.792e6", Some(3), Some(7)))?;
+    parses_to(b"299.792e6", num(Pos, "299.792e6", Some(3), Some(7)))?;
+    parses_to(b"-1.2e3", num(Neg, "1.2e3", Some(1), Some(3)))?;
 
     fails_with(b"-", num::Error::ExpectedDigit.into());
 
@@ -144,7 +155,7 @@ fn strings() -> Result<(), Error> {
 
     let escape = |e| Error::Str(str::Error::Escape(e));
 
-    fails_with(br#""\x""#, escape(escape::Error::UnknownKind));
+    fails_with(br#""\X""#, escape(escape::Error::UnknownKind));
     fails_with(br#""\U""#, escape(escape::Error::UnknownKind));
     fails_with(br#""\"#, escape(escape::Error::Eof));
     fails_with(br#""\u00"#, escape(escape::Error::Eof));
@@ -167,8 +178,8 @@ fn strings() -> Result<(), Error> {
 #[test]
 fn arrays() -> Result<(), Error> {
     parses_to(b"[]", arr([]))?;
-    parses_to(b"[false, true]", arr([bol(false), bol(true)]))?;
-    parses_to(b"[0, 1]", arr([int("0"), int("1")]))?;
+    parses_to(b"[false, true]", arr([boole(false), boole(true)]))?;
+    parses_to(b"[0, 1]", arr([nat("0"), nat("1")]))?;
     parses_to(b"[[]]", arr([arr([])]))?;
 
     fails_with(b"[", Expect::ValueOrEnd.into());
@@ -182,10 +193,10 @@ fn arrays() -> Result<(), Error> {
 #[test]
 fn objects() -> Result<(), Error> {
     parses_to(b"{}", obj([]))?;
-    parses_to(br#"{"a": 0}"#, obj([("a", int("0"))]))?;
+    parses_to(br#"{"a": 0}"#, obj([("a", nat("0"))]))?;
     parses_to(
         br#"{"a": 0, "b": 1}"#,
-        obj([("a", int("0")), ("b", int("1"))]),
+        obj([("a", nat("0")), ("b", nat("1"))]),
     )?;
 
     fails_with(b"{", Expect::ValueOrEnd.into());
@@ -201,6 +212,7 @@ fn objects() -> Result<(), Error> {
 fn binary_strings() -> Result<(), Error> {
     parses_to_binary_string(br#""aaa\nbbb\nccc""#, b"aaa\nbbb\nccc")?;
     parses_to_binary_string(b"\"aaa\xffbbb\xffccc\"", b"aaa\xffbbb\xffccc")?;
+    parses_to_binary_string(br#""a\xffb""#, b"a\xffb")?;
     parses_to_binary_string(
         b"\"aaa\\u2200\xe2\x88\x80ccc\"",
         "aaa\u{2200}\u{2200}ccc".as_bytes(),


### PR DESCRIPTION
- Support `\xHH` hex codes in strings.
- Allow parsing of custom literals, such as `NaN`.
- Make `-` a separate token, allowing the parsing of `-Infinity`.
- Make the notion of whitespace configurable, allowing comments.