### PR TITLE
Remove the `Token` type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "hifijson"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "memmap2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifijson"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Michael Färber <michael.faerber@gedenkt.at>"]
 description = "High-fidelity JSON lexer and parser"

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -59,7 +59,7 @@ fn hifi(s: &[u8]) {
     let mut lexer = hifijson::SliceLexer::new(s);
     //lexer.exactly_one(hifijson::ignore::parse).unwrap();
     lexer
-        .exactly_one(Lex::ws_token, hifijson::value::parse_unbounded)
+        .exactly_one(Lex::ws_peek, hifijson::value::parse_unbounded)
         .unwrap();
     //hifijson::serde::exactly_one::<serde_json::Value, _>(&mut lexer).unwrap();
 }

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -1,7 +1,15 @@
 //! JSON validator & pretty-printer.
+//!
+//! Test it with:
+//!
+//!     cargo run --example cat -- <<< '{"a": [null, 1, "b"]}'
+//!
+//! This should yield:
+//!
+//!     {"a":[null,1,"b"]}
 
 use core::ops::Deref;
-use hifijson::{str, value, Error, Expect, IterLexer, LexAlloc, LexWrite, SliceLexer, Token};
+use hifijson::{str, value, Error, Expect, IterLexer, LexAlloc, LexWrite, SliceLexer};
 use std::{fs, io};
 
 #[derive(Default)]
@@ -45,7 +53,7 @@ impl<Num: Deref<Target = str>, Str: Deref<Target = str>> TryFrom<value::Value<Nu
 fn process<L: LexAlloc>(cli: &Cli, lexer: &mut L) -> Result<(), Error> {
     if cli.parse {
         if cli.many {
-            let vs = core::iter::from_fn(|| Some(value::parse_unbounded(lexer.ws_token()?, lexer)));
+            let vs = core::iter::from_fn(|| Some(value::parse_unbounded(lexer.ws_peek()?, lexer)));
             for v in vs {
                 let v = v?;
                 if !cli.silent {
@@ -53,23 +61,23 @@ fn process<L: LexAlloc>(cli: &Cli, lexer: &mut L) -> Result<(), Error> {
                 };
             }
         } else {
-            let v = lexer.exactly_one(L::ws_token, value::parse_unbounded)?;
+            let v = lexer.exactly_one(L::ws_peek, value::parse_unbounded)?;
             if !cli.silent {
                 println!("{}", v)
             };
         }
     } else {
         let mut seen = false;
-        while let Some(token) = lexer.ws_token() {
+        while let Some(next) = lexer.ws_peek() {
             if seen && !cli.many {
                 Err(Expect::Eof)?
             }
             if cli.silent {
-                lex(token, lexer, &|_| ())?;
+                lex(next, lexer, |_| ())?;
             } else {
                 let path: Vec<_> = cli.path.as_deref().map(parse_path).unwrap_or(Vec::new());
                 use std::io::Write;
-                filter(&path, token, lexer, &|b| io::stdout().write_all(b).unwrap())?;
+                filter(&path, next, lexer, |b| io::stdout().write_all(b).unwrap())?;
             }
             seen = true;
         }
@@ -82,44 +90,44 @@ fn process<L: LexAlloc>(cli: &Cli, lexer: &mut L) -> Result<(), Error> {
 
 fn filter<L: LexAlloc>(
     path: &[PathElem],
-    token: Token,
+    next: u8,
     lexer: &mut L,
-    print: &impl Fn(&[u8]),
+    print: fn(&[u8]),
 ) -> Result<(), Error> {
     let (elem, rest) = if let Some(path) = path.split_first() {
         path
     } else {
-        lex(token, lexer, print)?;
+        lex(next, lexer, print)?;
         println!();
         return Ok(());
     };
 
-    match token {
-        Token::LSquare => {
+    match next {
+        b'[' => {
             let mut idx = 0;
-            lexer.seq(Token::RSquare, L::ws_token, |token, lexer| {
+            lexer.discarded().seq(b']', L::ws_peek, |next, lexer| {
                 let out = if elem.ints.is_empty() || elem.ints.contains(&idx) {
-                    filter(rest, token, lexer, print)
+                    filter(rest, next, lexer, print)
                 } else {
-                    hifijson::ignore::parse(token, lexer)
+                    hifijson::ignore::parse(next, lexer)
                 };
                 idx += 1;
                 out
             })?;
         }
-        Token::LCurly => {
+        b'{' => {
             let mut idx = 0;
-            lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
+            lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
                 idx += 1;
 
-                let key = lexer.str_colon(token, L::ws_token, |lexer| {
+                let key = lexer.str_colon(next, L::ws_peek, |lexer| {
                     lexer.str_string().map_err(Error::Str)
                 })?;
-                let token = lexer.ws_token().ok_or(Expect::Value)?;
+                let next = lexer.ws_peek().ok_or(Expect::Value)?;
                 if elem.strs.is_empty() || elem.strs.iter().any(|s| s == key.deref()) {
-                    filter(rest, token, lexer, print)
+                    filter(rest, next, lexer, print)
                 } else {
-                    hifijson::ignore::parse(token, lexer)
+                    hifijson::ignore::parse(next, lexer)
                 }
             })?;
         }
@@ -128,47 +136,47 @@ fn filter<L: LexAlloc>(
     Ok(())
 }
 
-fn lex<L: LexWrite>(token: Token, lexer: &mut L, print: &impl Fn(&[u8])) -> Result<(), Error> {
-    match token {
-        Token::Other(b'a'..=b'z') => print(match lexer.null_or_bool().ok_or(Expect::Value)? {
+fn lex<L: LexWrite>(next: u8, lexer: &mut L, print: fn(&[u8])) -> Result<(), Error> {
+    match next {
+        b'a'..=b'z' => print(match lexer.null_or_bool().ok_or(Expect::Value)? {
             None => b"null",
             Some(true) => b"true",
             Some(false) => b"false",
         }),
-        Token::Other(b'-') => {
+        b'-' => {
             print(b"-");
-            lex(Token::Other(b'0'), lexer.discarded(), print)?
+            lex(b'0', lexer.discarded(), print)?
         }
-        Token::Other(b'0'..=b'9') => {
+        b'0'..=b'9' => {
             let mut num = Default::default();
             let _pos = lexer.num_bytes(&mut num, b"")?;
             print(&num)
         }
-        Token::Quote => lex_string(lexer, print)?,
-        Token::LSquare => {
+        b'"' => lex_string(lexer.discarded(), print)?,
+        b'[' => {
             print(b"[");
             let mut first = true;
-            lexer.seq(Token::RSquare, L::ws_token, |token, lexer| {
+            lexer.discarded().seq(b']', L::ws_peek, |next, lexer| {
                 if !core::mem::take(&mut first) {
                     print(b",");
                 }
-                lex(token, lexer, print)
+                lex(next, lexer, print)
             })?;
             print(b"]");
         }
-        Token::LCurly => {
+        b'{' => {
             print(b"{");
             let mut first = true;
-            lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
+            lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
                 if !core::mem::take(&mut first) {
                     print(b",");
                 }
 
-                lexer.str_colon(token, L::ws_token, |lexer| {
+                lexer.str_colon(next, L::ws_peek, |lexer| {
                     lex_string(lexer, print).map_err(Error::Str)
                 })?;
                 print(b":");
-                lex(lexer.ws_token().ok_or(Expect::Value)?, lexer, print)
+                lex(lexer.ws_peek().ok_or(Expect::Value)?, lexer, print)
             })?;
             print(b"}")
         }
@@ -177,7 +185,7 @@ fn lex<L: LexWrite>(token: Token, lexer: &mut L, print: &impl Fn(&[u8])) -> Resu
     Ok(())
 }
 
-fn lex_string<L: LexWrite>(lexer: &mut L, print: &impl Fn(&[u8])) -> Result<(), str::Error> {
+fn lex_string<L: LexWrite>(lexer: &mut L, print: fn(&[u8])) -> Result<(), str::Error> {
     print(b"\"");
     let mut bytes = L::Bytes::default();
     lexer.str_bytes(&mut bytes)?;
@@ -205,7 +213,7 @@ fn process_stdin(cli: &Cli) -> io::Result<()> {
 fn parse_path(path: &str) -> Vec<PathElem> {
     use hifijson::token::Lex;
     let lexer = &mut SliceLexer::new(path.as_bytes());
-    core::iter::from_fn(|| Some(value::parse_unbounded(lexer.ws_token()?, lexer)))
+    core::iter::from_fn(|| Some(value::parse_unbounded(lexer.ws_peek()?, lexer)))
         .map(|e| PathElem::try_from(e.unwrap()).unwrap())
         .collect()
 }

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -27,9 +27,9 @@ fn count<L: Lex>(next: u8, lexer: &mut L) -> Result<usize, hifijson::Error> {
         b'{' => {
             let mut sum = 1;
             lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
-                lexer.str_colon(next, L::ws_peek, |lexer| {
-                    lexer.str_ignore().map_err(Error::Str)
-                })?;
+                lexer.expect(|_| Some(next), b'"').ok_or(Expect::String)?;
+                lexer.str_ignore().map_err(Error::Str)?;
+                lexer.expect(L::ws_peek, b':').ok_or(Expect::Colon)?;
                 sum += count(lexer.ws_peek().ok_or(Expect::Value)?, lexer)?;
                 Ok::<_, hifijson::Error>(())
             })?;

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -1,20 +1,20 @@
 //! Discarding values.
 
-use crate::{Error, Expect, Lex, Token};
+use crate::{Error, Expect, Lex};
 
 /// Parse and discard a value.
-pub fn parse<L: Lex>(token: Token, lexer: &mut L) -> Result<(), Error> {
-    match token {
-        Token::Other(b'a'..=b'z') => Ok(lexer.null_or_bool().map(|_| ()).ok_or(Expect::Value)?),
-        Token::Other(b'0'..=b'9') => Ok(lexer.num_ignore().map(|_| ())?),
-        Token::Other(b'-') => Ok(lexer.discarded().num_ignore().map(|_| ())?),
-        Token::Quote => Ok(lexer.str_ignore()?),
-        Token::LSquare => lexer.seq(Token::RSquare, L::ws_token, parse),
-        Token::LCurly => lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
-            lexer.str_colon(token, L::ws_token, |lexer| {
+pub fn parse<L: Lex>(next: u8, lexer: &mut L) -> Result<(), Error> {
+    match next {
+        b'a'..=b'z' => Ok(lexer.null_or_bool().map(|_| ()).ok_or(Expect::Value)?),
+        b'0'..=b'9' => Ok(lexer.num_ignore().map(|_| ())?),
+        b'-' => Ok(lexer.discarded().num_ignore().map(|_| ())?),
+        b'"' => Ok(lexer.discarded().str_ignore()?),
+        b'[' => lexer.discarded().seq(b']', L::ws_peek, parse),
+        b'{' => lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
+            lexer.str_colon(next, L::ws_peek, |lexer| {
                 lexer.str_ignore().map_err(Error::Str)
             })?;
-            parse(lexer.ws_token().ok_or(Expect::Value)?, lexer)
+            parse(lexer.ws_peek().ok_or(Expect::Value)?, lexer)
         }),
         _ => Err(Expect::Value)?,
     }

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -11,9 +11,9 @@ pub fn parse<L: Lex>(next: u8, lexer: &mut L) -> Result<(), Error> {
         b'"' => Ok(lexer.discarded().str_ignore()?),
         b'[' => lexer.discarded().seq(b']', L::ws_peek, parse),
         b'{' => lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
-            lexer.str_colon(next, L::ws_peek, |lexer| {
-                lexer.str_ignore().map_err(Error::Str)
-            })?;
+            lexer.expect(|_| Some(next), b'"').ok_or(Expect::String)?;
+            lexer.str_ignore().map_err(Error::Str)?;
+            lexer.expect(L::ws_peek, b':').ok_or(Expect::Colon)?;
             parse(lexer.ws_peek().ok_or(Expect::Value)?, lexer)
         }),
         _ => Err(Expect::Value)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,8 +171,11 @@
 //!             // perform the following for every key-value pair of the object
 //!             lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
 //!                 /// read the key, ignoring it, and then the ':' after it
-//!                 lexer.str_colon(next, L::ws_peek, |lexer| lexer.str_ignore().map_err(Error::Str))?;
-//!                 /// now peek the next non-whitespace character after ':'
+//!                 lexer.expect(|_| Some(next), b'"').ok_or(Expect::String)?;
+//!                 lexer.str_ignore().map_err(Error::Str)?;
+//!                 lexer.expect(L::ws_peek, b':').ok_or(Expect::Colon)?;
+//!
+//!                 /// peek the next non-whitespace character
 //!                 let next = lexer.ws_peek().ok_or(Expect::Value)?;
 //!                 sum += count(next, lexer)?;
 //!                 Ok::<_, Error>(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,8 +231,8 @@ use core::fmt::{self, Display};
 mod read;
 mod write;
 
-use read::Read;
-use write::Write;
+pub use read::Read;
+pub use write::Write;
 
 pub mod escape;
 pub mod num;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,36 +39,13 @@
 //! you can use [`value::parse_unbounded`].
 //! The choice is yours.
 //!
-//! In summary, hifijson aims to give you the tools to interpret JSON data
+//! In summary, hifijson aims to give you the tools to interpret JSON-like data
 //! flexibly and performantly.
 //!
 //! ## Lexers
 //!
-//! A *lexer* is a program that breaks up input into small units, and
-//! a parser combines these small units to transform them into the desired shape.
-//! For example, consider the JSON input `[null, {}]`.
-//! A lexer could break these into the units `[`, `null`, `,`, `{`, `}`, and `]`.
-//!
-//! JSON parsing consists of about three mostly independent lexing tasks:
-//! strings, numbers, and everything else (in decreasing order of difficulty).
-//! The "everything else" part is what I call a [token](Token).
-//! That includes:
-//! * `[`, `]` (start and end of an array)
-//! * `{`, `}` (start and end of an object)
-//! * `,`
-//! * `:`
-//! * `null`
-//! * `true`
-//! * `false`
-//! * `"` (start of a string)
-//! * `-` and any digit from 0 to 9 (start of a number)
-//!
-//! So every token has a maximal length (namely length 5).
-//!
-//! What about strings and numbers?
-//! The token lexer is not responsible for lexing them, but it
-//! returns special tokens to indicate that it has encountered the *start* of a string or number.
-//! Once that we get such a token, we can use one of the many string/number lexers,
+//! The hardest part of lexing JSON are strings and numbers.
+//! hifijson offers many different string/number lexers,
 //! which differ most prominently in their memory allocation behaviour.
 //! For example,
 //! * [`str::Lex::str_ignore`] discards a string,
@@ -157,7 +134,7 @@
 //!
 //! ## Operating on the lexer
 //!
-//! Often, it is better for performance to operate directly on the tokens that the lexer yields
+//! Often, it is better for performance to operate directly on the non-whitespace characters that the lexer yields
 //! rather than parsing everything into a value and then processing the value.
 //! For example, the following example counts the number of values in the input JSON.
 //! Unlike the previous examples, it requires only constant memory!
@@ -165,7 +142,7 @@
 //! ~~~
 //! use hifijson::{Error, Expect, Lex};
 //!
-//! /// Recursively count the number of values in the value starting with `token`.
+//! /// Recursively count the number of values in the value starting with the `next` character.
 //! ///
 //! /// The `Lex` trait indicates that this lexer does *not* allocate memory.
 //! fn count<L: Lex>(next: u8, lexer: &mut L) -> Result<usize, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 //! // now we are going -- we try to
 //! // obtain exactly one JSON value from the lexer and
 //! // parse it to a value, allowing for arbitrarily deep (unbounded) nesting
-//! let value = lexer.exactly_one(Lex::ws_token, |token, lexer| hifijson::value::parse_unbounded(token, lexer));
+//! let value = lexer.exactly_one(Lex::ws_peek, hifijson::value::parse_unbounded);
 //! let value = value.expect("parse");
 //!
 //! // yay, we got an array!
@@ -138,7 +138,7 @@
 //! ///
 //! /// Note that the `LexAlloc` trait indicates that this lexer allocates memory.
 //! fn process<L: hifijson::LexAlloc>(mut lexer: L) {
-//!     let value = lexer.exactly_one(L::ws_token, |token, lexer| hifijson::value::parse_unbounded(token, lexer));
+//!     let value = lexer.exactly_one(L::ws_peek, hifijson::value::parse_unbounded);
 //!     let value = value.expect("parse");
 //!     println!("{}", value);
 //! }
@@ -163,41 +163,41 @@
 //! Unlike the previous examples, it requires only constant memory!
 //!
 //! ~~~
-//! use hifijson::{Error, Expect, Lex, Token};
+//! use hifijson::{Error, Expect, Lex};
 //!
 //! /// Recursively count the number of values in the value starting with `token`.
 //! ///
 //! /// The `Lex` trait indicates that this lexer does *not* allocate memory.
-//! fn count<L: Lex>(token: Token, lexer: &mut L) -> Result<usize, Error> {
-//!     match token {
+//! fn count<L: Lex>(next: u8, lexer: &mut L) -> Result<usize, Error> {
+//!     match next {
 //!         // the JSON values "null", "true", and "false"
-//!         Token::Other(b'a'..=b'z') => Ok(lexer.null_or_bool().map(|_| 1).ok_or(Expect::Value)?),
-//!         Token::Other(b'0'..=b'9') => Ok(lexer.num_ignore().map(|_| 1)?),
-//!         Token::Other(b'-') => count(Token::Other(b'0'), lexer.discarded()),
-//!         Token::Quote => Ok(lexer.str_ignore().map(|_| 1)?),
+//!         b'a'..=b'z' => Ok(lexer.null_or_bool().map(|_| 1).ok_or(Expect::Value)?),
+//!         b'0'..=b'9' => Ok(lexer.num_ignore().map(|_| 1)?),
+//!         b'-' => count(b'0', lexer.discarded()),
+//!         b'"' => Ok(lexer.discarded().str_ignore().map(|_| 1)?),
 //!
-//!         // start of array ('[')
-//!         Token::LSquare => {
+//!         // start of array
+//!         b'[' => {
 //!             // an array is a value itself, so start with 1
 //!             let mut sum = 1;
 //!             // perform the following for every item of the array
-//!             lexer.seq(Token::RSquare, L::ws_token, |token, lexer| {
-//!                 sum += count(token, lexer)?;
+//!             lexer.discarded().seq(b']', L::ws_peek, |next, lexer| {
+//!                 sum += count(next, lexer)?;
 //!                 Ok::<_, Error>(())
 //!             })?;
 //!             Ok(sum)
 //!         }
 //!
-//!         // start of object ('{')
-//!         Token::LCurly => {
+//!         // start of object
+//!         b'{' => {
 //!             let mut sum = 1;
 //!             // perform the following for every key-value pair of the object
-//!             lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
+//!             lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
 //!                 /// read the key, ignoring it, and then the ':' after it
-//!                 lexer.str_colon(token, L::ws_token, |lexer| lexer.str_ignore().map_err(Error::Str))?;
-//!                 /// now read the token after ':'
-//!                 let token = lexer.ws_token().ok_or(Expect::Value)?;
-//!                 sum += count(token, lexer)?;
+//!                 lexer.str_colon(next, L::ws_peek, |lexer| lexer.str_ignore().map_err(Error::Str))?;
+//!                 /// now peek the next non-whitespace character after ':'
+//!                 let next = lexer.ws_peek().ok_or(Expect::Value)?;
+//!                 sum += count(next, lexer)?;
 //!                 Ok::<_, Error>(())
 //!             })?;
 //!             Ok(sum)
@@ -207,7 +207,7 @@
 //! }
 //!
 //! fn process<L: Lex>(mut lexer: L) -> Result<usize, Error> {
-//!     lexer.exactly_one(L::ws_token, |token, lexer| count(token, lexer))
+//!     lexer.exactly_one(L::ws_peek, count)
 //! }
 //!
 //! let json = br#"[null, true, false, "hello", 0, 3.1415, [1, 2], {"x": 1, "y": 2}]"#;
@@ -262,7 +262,7 @@ pub mod num;
 pub mod str;
 pub mod token;
 
-pub use token::{Expect, Token};
+pub use token::Expect;
 
 pub mod ignore;
 #[cfg(feature = "serde")]

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,6 +1,8 @@
 /// Low-level input operations.
 pub trait Read {
     /// Return `true` if the given byte sequence is a prefix of the input.
+    ///
+    /// This function may advance the input even if it returns `false`.
     fn strip_prefix(&mut self, s: &[u8]) -> bool {
         for c1 in s {
             match self.take_next() {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -9,7 +9,7 @@
 //! assert_eq!(vec![0, 1], value);
 //! ~~~
 
-use crate::{Expect, Lex, LexAlloc, Token};
+use crate::{Expect, Lex, LexAlloc};
 
 use alloc::string::{String, ToString};
 use core::fmt;
@@ -50,7 +50,7 @@ impl de::Error for Error {
 }
 
 struct TokenLexer<L> {
-    token: Token,
+    next: u8,
     lexer: L,
 }
 
@@ -61,8 +61,8 @@ fn parse_number<T: core::str::FromStr>(n: &str) -> Result<T> {
 macro_rules! deserialize_number {
     ($deserialize:ident, $visit:ident) => {
         fn $deserialize<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-            let (prefix, lexer) = match self.token {
-                Token::Other(b'-') => ("-", self.lexer.discarded()),
+            let (prefix, lexer) = match self.next {
+                b'-' => ("-", self.lexer.discarded()),
                 _ => ("", self.lexer),
             };
             let (n, _parts) = lexer.num_string(prefix).map_err(crate::Error::Num)?;
@@ -88,16 +88,16 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
         };
 
         use crate::Error::{Num, Str};
-        match self.token {
-            Token::Other(b'a'..=b'z') => match self.lexer.null_or_bool().ok_or(Expect::Value)? {
+        match self.next {
+            b'a'..=b'z' => match self.lexer.null_or_bool().ok_or(Expect::Value)? {
                 None => visitor.visit_unit(),
                 Some(b) => visitor.visit_bool(b),
             },
-            Token::Other(b'0'..=b'9') => num(self.lexer, visitor, ""),
-            Token::Other(b'-') => num(self.lexer.discarded(), visitor, "-"),
-            Token::Quote => visitor.visit_str(&self.lexer.str_string().map_err(Str)?),
-            Token::LSquare => visitor.visit_seq(CommaSeparated::new(self.lexer)),
-            Token::LCurly => visitor.visit_map(CommaSeparated::new(self.lexer)),
+            b'0'..=b'9' => num(self.lexer, visitor, ""),
+            b'-' => num(self.lexer.discarded(), visitor, "-"),
+            b'"' => visitor.visit_str(&self.lexer.discarded().str_string().map_err(Str)?),
+            b'[' => visitor.visit_seq(CommaSeparated::new(self.lexer.discarded())),
+            b'{' => visitor.visit_map(CommaSeparated::new(self.lexer.discarded())),
             _ => Err(Expect::Value)?,
         }
     }
@@ -137,12 +137,12 @@ impl<'a, L> CommaSeparated<'a, L> {
 
 impl<'a, L: Lex> CommaSeparated<'a, L> {
     // Comma is required before every element except the first.
-    fn comma(&mut self, token: &mut Token) -> Result<()> {
+    fn comma(&mut self, next: &mut u8) -> Result<()> {
         if !core::mem::take(&mut self.first) {
-            if *token != Token::Comma {
-                Err(Expect::CommaOrEnd)?
+            if *next == b',' {
+                *next = self.lexer.discarded().ws_peek().ok_or(Expect::Value)?;
             } else {
-                *token = self.lexer.ws_token().ok_or(Expect::Value)?;
+                Err(Expect::CommaOrEnd)?
             }
         }
         Ok(())
@@ -156,15 +156,15 @@ impl<'de, 'a, L: LexAlloc + 'de> de::SeqAccess<'de> for CommaSeparated<'a, L> {
     where
         T: DeserializeSeed<'de>,
     {
-        let token = self.lexer.ws_token();
-        let mut token = token.ok_or(Expect::ValueOrEnd)?;
-        if token == Token::RSquare {
+        let mut next = self.lexer.ws_peek().ok_or(Expect::ValueOrEnd)?;
+        if next == b']' {
+            self.lexer.take_next();
             return Ok(None);
         };
-        self.comma(&mut token)?;
+        self.comma(&mut next)?;
 
         let lexer = &mut *self.lexer;
-        seed.deserialize(TokenLexer { token, lexer }).map(Some)
+        seed.deserialize(TokenLexer { next, lexer }).map(Some)
     }
 }
 
@@ -175,19 +175,19 @@ impl<'de, 'a, L: LexAlloc + 'de> de::MapAccess<'de> for CommaSeparated<'a, L> {
     where
         K: DeserializeSeed<'de>,
     {
-        let token = self.lexer.ws_token();
-        let mut token = token.ok_or(Expect::ValueOrEnd)?;
-        if token == Token::RCurly {
+        let mut next = self.lexer.ws_peek().ok_or(Expect::ValueOrEnd)?;
+        if next == b'}' {
+            self.lexer.take_next();
             return Ok(None);
         };
-        self.comma(&mut token)?;
+        self.comma(&mut next)?;
 
-        if token != Token::Quote {
+        if next != b'"' {
             Err(Expect::String)?
         }
 
         let lexer = &mut *self.lexer;
-        seed.deserialize(TokenLexer { token, lexer }).map(Some)
+        seed.deserialize(TokenLexer { next, lexer }).map(Some)
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
@@ -195,17 +195,20 @@ impl<'de, 'a, L: LexAlloc + 'de> de::MapAccess<'de> for CommaSeparated<'a, L> {
         V: DeserializeSeed<'de>,
     {
         let lexer = &mut *self.lexer;
-        let colon = lexer.ws_token().filter(|t| *t == Token::Colon);
-        colon.ok_or(Expect::Colon)?;
+        if lexer.ws_peek() == Some(b':') {
+            lexer.take_next();
+        } else {
+            Err(Expect::Colon)?
+        }
 
-        let token = lexer.ws_token().ok_or(Expect::Value)?;
-        seed.deserialize(TokenLexer { token, lexer })
+        let next = lexer.ws_peek().ok_or(Expect::Value)?;
+        seed.deserialize(TokenLexer { next, lexer })
     }
 }
 
 /// Deserialise a single value.
 pub fn exactly_one<'a, T: Deserialize<'a>, L: LexAlloc + 'a>(lexer: &mut L) -> Result<T> {
-    lexer.exactly_one(L::ws_token, |token, lexer| {
-        T::deserialize(TokenLexer { token, lexer })
+    lexer.exactly_one(L::ws_peek, |next, lexer| {
+        T::deserialize(TokenLexer { next, lexer })
     })
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -31,55 +31,6 @@ impl core::fmt::Display for Expect {
     }
 }
 
-/// JSON lexer token.
-#[derive(Debug, PartialEq, Eq)]
-pub enum Token {
-    /// `,`
-    Comma,
-    /// `:`
-    Colon,
-    /// `[`
-    LSquare,
-    /// `]`
-    RSquare,
-    /// `{`
-    LCurly,
-    /// `}`
-    RCurly,
-    /// `"`
-    Quote,
-    /// anything else
-    Other(u8),
-}
-
-impl core::fmt::Display for Token {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        use Token::*;
-        match self {
-            Comma => ',',
-            Colon => ':',
-            LSquare => '[',
-            RSquare => ']',
-            LCurly => '{',
-            RCurly => '}',
-            Quote => '"',
-            Other(b) => char::from(*b),
-        }
-        .fmt(f)
-    }
-}
-
-impl Token {
-    /// Return `Ok(())` if `self` equals `token`, else return `Err(err)`.
-    pub fn equals_or<E>(&self, token: Token, err: E) -> Result<(), E> {
-        if *self == token {
-            Ok(())
-        } else {
-            Err(err)
-        }
-    }
-}
-
 /// Lexing that does not require allocation.
 pub trait Lex: crate::Read {
     /// Skip input until the earliest non-whitespace character.
@@ -87,10 +38,10 @@ pub trait Lex: crate::Read {
         self.skip_until(|c| !matches!(c, b' ' | b'\t' | b'\r' | b'\n'))
     }
 
-    /// Skip potential whitespace and return the following token if there is some.
-    fn ws_token(&mut self) -> Option<Token> {
+    /// Skip whitespace and peek at the following character.
+    fn ws_peek(&mut self) -> Option<u8> {
         self.eat_whitespace();
-        self.peek_next().map(|next| self.token(next))
+        self.peek_next()
     }
 
     /// Parse a JSON token starting with a letter.
@@ -104,29 +55,6 @@ pub trait Lex: crate::Read {
         })
     }
 
-    /// Convert a character to a token, such as '`:`' to [`Token::Colon`].
-    ///
-    /// Only when the token consists of a single character that can be
-    /// reconstructed losslessly from the token, such as `[` or `:`,
-    /// then the current character is consumed.
-    /// All other non-token characters are preserved, i.e. input is not advanced.
-    fn token(&mut self, c: u8) -> Token {
-        let token = match c {
-            b'"' => Token::Quote,
-            b'[' => Token::LSquare,
-            b']' => Token::RSquare,
-            b'{' => Token::LCurly,
-            b'}' => Token::RCurly,
-            b',' => Token::Comma,
-            b':' => Token::Colon,
-            // it is important to `return` here in order not to take the next byte,
-            // like we do for the regular, single-character tokens
-            _ => return Token::Other(c),
-        };
-        self.take_next();
-        token
-    }
-
     /// Take next token, discard it, and return mutable handle to lexer.
     ///
     /// This is useful in particular when parsing negative numbers,
@@ -137,38 +65,48 @@ pub trait Lex: crate::Read {
     }
 
     /// Parse a string with given function, followed by a colon.
-    fn str_colon<T, E: From<Expect>, TF, F>(&mut self, token: Token, tf: TF, f: F) -> Result<T, E>
+    fn str_colon<T, E: From<Expect>, PF, F>(&mut self, next: u8, pf: PF, f: F) -> Result<T, E>
     where
-        TF: FnOnce(&mut Self) -> Option<Token>,
+        PF: FnOnce(&mut Self) -> Option<u8>,
         F: FnOnce(&mut Self) -> Result<T, E>,
     {
-        token.equals_or(Token::Quote, Expect::String)?;
+        if next == b'"' {
+            self.take_next();
+        } else {
+            Err(Expect::String)?
+        }
         let key = f(self)?;
 
-        let colon = tf(self).filter(|t| *t == Token::Colon);
-        colon.ok_or(Expect::Colon)?;
+        if pf(self) == Some(b':') {
+            self.take_next();
+        } else {
+            Err(Expect::Colon)?
+        }
 
         Ok(key)
     }
 
     /// Execute `f` for every item in the comma-separated sequence until `end`.
-    fn seq<E: From<Expect>, TF, F>(&mut self, end: Token, mut tf: TF, mut f: F) -> Result<(), E>
+    fn seq<E: From<Expect>, PF, F>(&mut self, end: u8, mut pf: PF, mut f: F) -> Result<(), E>
     where
-        TF: FnMut(&mut Self) -> Option<Token>,
-        F: FnMut(Token, &mut Self) -> Result<(), E>,
+        PF: FnMut(&mut Self) -> Option<u8>,
+        F: FnMut(u8, &mut Self) -> Result<(), E>,
     {
-        let mut token = tf(self).ok_or(Expect::ValueOrEnd)?;
-        if token == end {
+        let mut next = pf(self).ok_or(Expect::ValueOrEnd)?;
+        if next == end {
+            self.take_next();
             return Ok(());
         };
 
         loop {
-            f(token, self)?;
-            token = tf(self).ok_or(Expect::CommaOrEnd)?;
-            if token == end {
+            f(next, self)?;
+            next = pf(self).ok_or(Expect::CommaOrEnd)?;
+            if next == end {
+                self.take_next();
                 return Ok(());
-            } else if token == Token::Comma {
-                token = tf(self).ok_or(Expect::Value)?;
+            } else if next == b',' {
+                self.take_next();
+                next = pf(self).ok_or(Expect::Value)?;
             } else {
                 return Err(Expect::CommaOrEnd)?;
             }
@@ -176,15 +114,14 @@ pub trait Lex: crate::Read {
     }
 
     /// Parse once using given function and assure that the function has consumed all tokens.
-    fn exactly_one<T, E: From<Expect>, TF, F>(&mut self, mut tf: TF, f: F) -> Result<T, E>
+    fn exactly_one<T, E: From<Expect>, PF, F>(&mut self, mut pf: PF, f: F) -> Result<T, E>
     where
-        TF: FnMut(&mut Self) -> Option<Token>,
-        F: FnOnce(Token, &mut Self) -> Result<T, E>,
+        PF: FnMut(&mut Self) -> Option<u8>,
+        F: FnOnce(u8, &mut Self) -> Result<T, E>,
     {
-        let token = tf(self).ok_or(Expect::Value)?;
-        let v = f(token, self)?;
-        self.eat_whitespace();
-        match self.peek_next() {
+        let next = pf(self).ok_or(Expect::Value)?;
+        let v = f(next, self)?;
+        match pf(self) {
             None => Ok(v),
             Some(_) => Err(Expect::Eof)?,
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
 //! Parsing and values.
 
-use crate::{num, str, token, Error, LexAlloc, Token};
+use crate::{num, str, token, Error, LexAlloc};
 use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Deref;
@@ -72,33 +72,31 @@ impl<Num: Deref<Target = str>, Str: Deref<Target = str>> fmt::Display for Value<
 
 /// Parse a value, using `f` to parse recursive values inside arrays / objects.
 fn parse<L: LexAlloc>(
-    token: Token,
+    next: u8,
     lexer: &mut L,
-    f: impl Fn(Token, &mut L) -> Result<Value<L::Num, L::Str>, Error>,
+    f: impl Fn(u8, &mut L) -> Result<Value<L::Num, L::Str>, Error>,
 ) -> Result<Value<L::Num, L::Str>, Error> {
     let nob = |o: Option<bool>| o.map(Value::Bool).unwrap_or(Value::Null);
-    match token {
-        Token::Other(b'a'..=b'z') => {
-            Ok(lexer.null_or_bool().map(nob).ok_or(token::Expect::Value)?)
-        }
-        Token::Other(b'-') => Ok(Value::Number(lexer.discarded().num_string("-")?)),
-        Token::Other(b'0'..=b'9') => Ok(Value::Number(lexer.num_string("")?)),
-        Token::Quote => Ok(Value::String(lexer.str_string()?)),
-        Token::LSquare => Ok(Value::Array({
+    match next {
+        b'a'..=b'z' => Ok(lexer.null_or_bool().map(nob).ok_or(token::Expect::Value)?),
+        b'-' => Ok(Value::Number(lexer.discarded().num_string("-")?)),
+        b'0'..=b'9' => Ok(Value::Number(lexer.num_string("")?)),
+        b'"' => Ok(Value::String(lexer.discarded().str_string()?)),
+        b'[' => Ok(Value::Array({
             let mut arr = Vec::new();
-            lexer.seq(Token::RSquare, L::ws_token, |token, lexer| {
-                arr.push(f(token, lexer)?);
+            lexer.discarded().seq(b']', L::ws_peek, |next, lexer| {
+                arr.push(f(next, lexer)?);
                 Ok::<_, Error>(())
             })?;
             arr
         })),
-        Token::LCurly => Ok(Value::Object({
+        b'{' => Ok(Value::Object({
             let mut obj = Vec::new();
-            lexer.seq(Token::RCurly, L::ws_token, |token, lexer| {
-                let key = lexer.str_colon(token, L::ws_token, |lexer| {
+            lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {
+                let key = lexer.str_colon(next, L::ws_peek, |lexer| {
                     lexer.str_string().map_err(Error::Str)
                 })?;
-                let value = f(lexer.ws_token().ok_or(token::Expect::Value)?, lexer)?;
+                let value = f(lexer.ws_peek().ok_or(token::Expect::Value)?, lexer)?;
                 obj.push((key, value));
                 Ok::<_, Error>(())
             })?;
@@ -112,10 +110,10 @@ fn parse<L: LexAlloc>(
 ///
 /// To prevent stack overflows, consider using [`parse_bounded`].
 pub fn parse_unbounded<L: LexAlloc>(
-    token: Token,
+    next: u8,
     lexer: &mut L,
 ) -> Result<Value<L::Num, L::Str>, Error> {
-    parse(token, lexer, parse_unbounded)
+    parse(next, lexer, parse_unbounded)
 }
 
 /// Parse an value, limiting the recursion to `depth`.
@@ -123,9 +121,9 @@ pub fn parse_unbounded<L: LexAlloc>(
 /// This serves to prevent stack overflows.
 pub fn parse_bounded<L: LexAlloc>(
     depth: usize,
-    token: Token,
+    next: u8,
     lexer: &mut L,
 ) -> Result<Value<L::Num, L::Str>, Error> {
     let d = depth.checked_sub(1).ok_or(Error::Depth)?;
-    parse(token, lexer, |token, lexer| parse_bounded(d, token, lexer))
+    parse(next, lexer, |next, lexer| parse_bounded(d, next, lexer))
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,9 +1,25 @@
+/// Writing input to bytes.
+///
+/// This is useful to capture a part of the input,
+/// without allocating when the input is a slice.
 pub trait Write {
+    /// Type of bytes to write to.
     type Bytes: core::ops::Deref<Target = [u8]> + Default;
 
     /// Write input to `bytes` until `stop` yields true.
     ///
     /// This function does not return a new [`Self::Bytes`] to avoid allocations.
+    ///
+    /// ~~~
+    /// fn test<L: hifijson::Write>(lexer: &mut L) {
+    ///     let mut bytes = L::Bytes::default();
+    ///     lexer.write_until(&mut bytes, |c| c == b' ');
+    ///     assert_eq!(&*bytes, b"Hello");
+    /// }
+    /// let s = b"Hello World";
+    /// test(&mut hifijson::SliceLexer::new(s));
+    /// test(&mut hifijson::IterLexer::new(s.iter().copied().map(Ok::<_, ()>)));
+    /// ~~~
     fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(u8) -> bool);
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -15,6 +15,8 @@ pub trait Write {
     ///     let mut bytes = L::Bytes::default();
     ///     lexer.write_until(&mut bytes, |c| c == b' ');
     ///     assert_eq!(&*bytes, b"Hello");
+    ///     lexer.write_until(&mut bytes, |_| false);
+    ///     assert_eq!(&*bytes, b" World");
     /// }
     /// let s = b"Hello World";
     /// test(&mut hifijson::SliceLexer::new(s));


### PR DESCRIPTION
This uses just `u8` instead of a dedicated `Token` type.