### PR TITLE
Simplify number lexing

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -149,7 +149,7 @@ fn lex<L: LexWrite>(next: u8, lexer: &mut L, print: fn(&[u8])) -> Result<(), Err
         }
         b'0'..=b'9' => {
             let mut num = Default::default();
-            let _pos = lexer.num_bytes(&mut num, b"")?;
+            let _pos = lexer.num_bytes(&mut num)?;
             print(&num)
         }
         b'"' => lex_string(lexer.discarded(), print)?,

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -124,7 +124,7 @@ fn filter<L: LexAlloc>(
                 let key = lexer.str_string().map_err(Error::Str)?;
                 lexer.expect(L::ws_peek, b':').ok_or(Expect::Colon)?;
                 let next = lexer.ws_peek().ok_or(Expect::Value)?;
-                if elem.strs.is_empty() || elem.strs.iter().any(|s| s == key.deref()) {
+                if elem.strs.is_empty() || elem.strs.iter().any(|s| s == key.as_ref()) {
                     filter(rest, next, lexer, print)
                 } else {
                     hifijson::ignore::parse(next, lexer)
@@ -143,7 +143,7 @@ fn lex<L: LexWrite>(next: u8, lexer: &mut L, print: fn(&[u8])) -> Result<(), Err
             Some(true) => b"true",
             Some(false) => b"false",
         }),
-        b'0'..=b'9' | b'-' => print(&lexer.num_bytes().validated()?.0),
+        b'0'..=b'9' | b'-' => print(lexer.num_bytes().validated()?.0.as_ref()),
         b'"' => lex_string(lexer.discarded(), print)?,
         b'[' => {
             print(b"[");
@@ -182,7 +182,7 @@ fn lex_string<L: LexWrite>(lexer: &mut L, print: fn(&[u8])) -> Result<(), str::E
     print(b"\"");
     let mut bytes = L::Bytes::default();
     lexer.str_bytes(&mut bytes)?;
-    print(&bytes);
+    print(bytes.as_ref());
     print(b"\"");
     Ok(())
 }

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -143,15 +143,7 @@ fn lex<L: LexWrite>(next: u8, lexer: &mut L, print: fn(&[u8])) -> Result<(), Err
             Some(true) => b"true",
             Some(false) => b"false",
         }),
-        b'-' => {
-            print(b"-");
-            lex(b'0', lexer.discarded(), print)?
-        }
-        b'0'..=b'9' => {
-            let mut num = Default::default();
-            let _pos = lexer.num_bytes(&mut num)?;
-            print(&num)
-        }
+        b'0'..=b'9' | b'-' => print(&lexer.num_bytes().validated()?.0),
         b'"' => lex_string(lexer.discarded(), print)?,
         b'[' => {
             print(b"[");

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -13,8 +13,7 @@ use hifijson::{Error, Expect, Lex};
 fn count<L: Lex>(next: u8, lexer: &mut L) -> Result<usize, hifijson::Error> {
     match next {
         b'a'..=b'z' => Ok(lexer.null_or_bool().map(|_| 1).ok_or(Expect::Value)?),
-        b'0'..=b'9' => Ok(lexer.num_ignore().map(|_| 1)?),
-        b'-' => Ok(lexer.discarded().num_ignore().map(|_| 1)?),
+        b'0'..=b'9' | b'-' => Ok(lexer.num_ignore().validate().map(|_| 1)?),
         b'"' => Ok(lexer.discarded().str_ignore().map(|_| 1)?),
         b'[' => {
             let mut sum = 1;

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -6,8 +6,7 @@ use crate::{Error, Expect, Lex};
 pub fn parse<L: Lex>(next: u8, lexer: &mut L) -> Result<(), Error> {
     match next {
         b'a'..=b'z' => Ok(lexer.null_or_bool().map(|_| ()).ok_or(Expect::Value)?),
-        b'0'..=b'9' => Ok(lexer.num_ignore().map(|_| ())?),
-        b'-' => Ok(lexer.discarded().num_ignore().map(|_| ())?),
+        b'0'..=b'9' | b'-' => Ok(lexer.num_ignore().validate().map(|_| ())?),
         b'"' => Ok(lexer.discarded().str_ignore()?),
         b'[' => lexer.discarded().seq(b']', L::ws_peek, parse),
         b'{' => lexer.discarded().seq(b'}', L::ws_peek, |next, lexer| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,7 @@
 //!     match next {
 //!         // the JSON values "null", "true", and "false"
 //!         b'a'..=b'z' => Ok(lexer.null_or_bool().map(|_| 1).ok_or(Expect::Value)?),
-//!         b'0'..=b'9' => Ok(lexer.num_ignore().map(|_| 1)?),
-//!         b'-' => count(b'0', lexer.discarded()),
+//!         b'0'..=b'9' | b'-' => Ok(lexer.num_ignore().validate().map(|_| 1)?),
 //!         b'"' => Ok(lexer.discarded().str_ignore().map(|_| 1)?),
 //!
 //!         // start of array
@@ -264,7 +263,6 @@ impl<T> LexAlloc for T where T: LexWrite + str::LexAlloc {}
 
 /// JSON lexer from a shared byte slice.
 pub struct SliceLexer<'a> {
-    whole: &'a [u8],
     slice: &'a [u8],
 }
 
@@ -275,20 +273,27 @@ impl<'a> SliceLexer<'a> {
     /// see for example the [memmap2](https://docs.rs/memmap2) crate.
     ///
     pub fn new(slice: &'a [u8]) -> Self {
-        let whole = slice;
-        Self { whole, slice }
+        Self { slice }
     }
 
     /// Return remaining input as a subslice of the original data.
     ///
-    /// This can be used to find the place where an error occurred.
+    /// This can be used to obtain the number of bytes consumed, e.g.
+    /// to find the place where an error occurred:
+    ///
+    /// ~~~
+    /// use hifijson::{token::Lex, value, Read};
+    /// let input = b"true false";
+    /// let mut lexer = hifijson::SliceLexer::new(input);
+    /// let parse = || Some(value::parse_unbounded(lexer.ws_peek()?, &mut lexer));
+    /// let mut vals = core::iter::from_fn(parse);
+    ///
+    /// assert_eq!(vals.next(), Some(Ok(value::Value::Bool(true))));
+    /// let offset = lexer.as_slice().as_ptr() as usize - input.as_ptr() as usize;
+    /// assert_eq!(offset, 4);
+    /// ~~~
     pub fn as_slice(&self) -> &'a [u8] {
         self.slice
-    }
-
-    /// Number of bytes consumed so far.
-    fn offset(&self) -> usize {
-        self.slice.as_ptr() as usize - self.whole.as_ptr() as usize
     }
 }
 

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,18 +1,30 @@
 //! Positive numbers.
+//!
+//! The lexers in this modules, in particular
+//! [`Lex::num_ignore`] and
+//! [`LexWrite::num_string`],
+//! accept numbers corresponding to the regex
+//! `\d+(\.\d+)?([eE]\d+)?`.
+//! This is strictly more general than the JSON specification,
+//! which specifies numbers as
+//! `(0|[1-9]\d*)(\.\d+)?([eE]\d+)?`.
+//! That excludes numbers like `007`, which are accepted by the former regex.
+//!
+//! If you require stricter conformance to JSON numbers,
+//! you can rule out lexed numbers that start with `0\d` manually after lexing.
 
 use crate::{Read, Write};
 use core::fmt::{self, Display};
-use core::num::NonZeroUsize;
-
 /// Number lexing error.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// The only thing that can go wrong during number lexing is
-    /// that we are not reading even a single digit.
-    /// Once a single digit has been read,
-    /// unexpected sequences afterwards are ignored by this lexer.
-    /// For example, if the lexer encounters `42abc`,
-    /// it returns only `42` and does not touch `abc`.
+    /// that we are not reading a digit where we expected one.
+    /// For example:
+    ///
+    /// - `""`
+    /// - `"0."`
+    /// - `"0.1e"`
     ExpectedDigit,
 }
 
@@ -31,9 +43,9 @@ impl Display for Error {
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Parts {
     /// position of the dot
-    pub dot: Option<NonZeroUsize>,
+    pub dot: Option<usize>,
     /// position of the exponent character (`e`/`E`)
-    pub exp: Option<NonZeroUsize>,
+    pub exp: Option<usize>,
 }
 
 impl Parts {
@@ -45,141 +57,71 @@ impl Parts {
 
 /// Number lexing, ignoring the number.
 pub trait Lex: Read {
-    /// Perform `f` for every digit read and return the number of read bytes.
-    fn digits_foreach(&mut self, mut f: impl FnMut(u8)) -> usize {
-        let mut len = 0;
-        while let Some(digit @ (b'0'..=b'9')) = self.peek_next() {
-            f(digit);
-            self.take_next();
-            len += 1;
-        }
-        len
-    }
-
-    /// Run function for every digit, fail if no digit encountered.
-    fn digits1_foreach(&mut self, f: impl FnMut(u8)) -> Result<NonZeroUsize, Error> {
-        NonZeroUsize::new(self.digits_foreach(f)).ok_or(Error::ExpectedDigit)
-    }
-
-    /// Run function for each character of a number.
-    fn num_foreach(&mut self, mut f: impl FnMut(u8)) -> Result<Parts, Error> {
-        let mut pos = 0;
-        let mut parts = Parts::default();
-
-        match self.take_next() {
-            Some(b'0') => {
-                f(b'0');
-                pos += 1;
-            }
-            Some(digit @ b'1'..=b'9') => {
-                f(digit);
-                pos += 1 + self.digits_foreach(&mut f);
-            }
-            _ => return Err(Error::ExpectedDigit),
-        }
-
-        loop {
-            match self.peek_next() {
-                Some(b'.') if parts.is_int() => {
-                    parts.dot = Some(NonZeroUsize::new(pos).unwrap());
-                    f(b'.');
-                    self.take_next();
-                    pos += 1 + self.digits1_foreach(&mut f)?.get();
-                }
-
-                Some(exp @ (b'e' | b'E')) if parts.exp.is_none() => {
-                    parts.exp = Some(NonZeroUsize::new(pos).unwrap());
-                    f(exp);
-                    self.take_next();
-
-                    if let Some(sign @ (b'+' | b'-')) = self.peek_next() {
-                        f(sign);
-                        self.take_next();
-                        pos += 1;
-                    }
-
-                    pos += 1 + self.digits1_foreach(&mut f)?.get();
-                }
-                _ => return Ok(parts),
-            }
-        }
-    }
-
     /// Lex a number and ignore its contents, saving only its parts.
     fn num_ignore(&mut self) -> Result<Parts, Error> {
-        self.num_foreach(|_| ())
+        let mut parts = Parts::default();
+        let mut len = 0;
+        let mut prev = None;
+        self.skip_until(|c| {
+            parts.num_end(len, prev, c) || {
+                len += 1;
+                prev = Some(c);
+                false
+            }
+        });
+        let valid = prev.as_ref().map_or(false, u8::is_ascii_digit);
+        valid.then(|| parts).ok_or(Error::ExpectedDigit)
     }
 }
 
 impl<T> Lex for T where T: Read {}
+
+impl Parts {
+    /// Returns whether the next character `c` terminates the current number.
+    fn num_end(&mut self, len: usize, prev: Option<u8>, c: u8) -> bool {
+        let prev_digit = || prev.map_or(false, |c| c.is_ascii_digit());
+        match c {
+            _ if c.is_ascii_digit() => false,
+            b'.' if self.dot.is_none() && self.exp.is_none() && prev_digit() => {
+                self.dot = Some(len);
+                false
+            }
+            b'e' | b'E' if self.exp.is_none() && prev_digit() => {
+                self.exp = Some(len);
+                false
+            }
+            _ => true,
+        }
+    }
+}
 
 /// Number lexing, keeping the number.
 pub trait LexWrite: Lex + Write {
     /// String type to save numbers as.
     type Num: core::ops::Deref<Target = str>;
 
-    /// Write a prefix and a number to bytes and save its parts.
+    /// Lex a number, append it to `num`, and save its parts.
     ///
-    /// `prefix` must be a suffix of the previously consumed input.
+    /// `num` must be a suffix of the previously consumed input.
     /// Normally, you pass `b"-"` as prefix if you read "-" just before.
     /// This allows you to include "-" in the bytes without allocation.
-    fn num_bytes(&mut self, bytes: &mut Self::Bytes, prefix: &[u8]) -> Result<Parts, Error>;
-    /// Write a prefix and a number to a string and save its parts.
-    fn num_string(&mut self, prefix: &str) -> Result<(Self::Num, Parts), Error>;
-}
+    fn num_bytes(&mut self, num: &mut Self::Bytes) -> Result<Parts, Error> {
+        let mut parts = Parts::default();
+        self.append_until(num, |b, c| parts.num_end(b.len(), b.last().copied(), c));
+        let valid = num.last().map_or(false, u8::is_ascii_digit);
+        valid.then(|| parts).ok_or(Error::ExpectedDigit)
+    }
 
-fn digits(s: &[u8]) -> usize {
-    s.iter()
-        .position(|c| !c.is_ascii_digit())
-        .unwrap_or(s.len())
+    /// Write a prefix and a number to a string and save its parts.
+    fn num_string(&mut self, prefix: &'static str) -> Result<(Self::Num, Parts), Error>;
 }
 
 impl<'a> LexWrite for crate::SliceLexer<'a> {
     type Num = &'a str;
 
-    fn num_bytes(&mut self, bytes: &mut Self::Bytes, prefix: &[u8]) -> Result<Parts, Error> {
-        // rewind by prefix length
-        self.slice = &self.whole[self.offset() - prefix.len()..];
-        assert!(self.slice.starts_with(prefix));
-
-        let mut pos = prefix.len();
-        let mut parts = Parts::default();
-
-        let digits1 = |s| NonZeroUsize::new(digits(s)).ok_or(Error::ExpectedDigit);
-
-        pos += if self.slice.get(pos) == Some(&b'0') {
-            1
-        } else {
-            digits1(&self.slice[pos..])?.get()
-        };
-
-        loop {
-            match self.slice.get(pos) {
-                Some(b'.') if parts.dot.is_none() && parts.exp.is_none() => {
-                    parts.dot = Some(NonZeroUsize::new(pos).unwrap());
-                    pos += 1;
-                    pos += digits1(&self.slice[pos..])?.get()
-                }
-                Some(b'e' | b'E') if parts.exp.is_none() => {
-                    parts.exp = Some(NonZeroUsize::new(pos).unwrap());
-                    pos += 1;
-                    if matches!(self.slice.get(pos), Some(b'+' | b'-')) {
-                        pos += 1;
-                    }
-                    pos += digits1(&self.slice[pos..])?.get()
-                }
-                None | Some(_) => {
-                    *bytes = &self.slice[..pos];
-                    self.slice = &self.slice[pos..];
-                    return Ok(parts);
-                }
-            }
-        }
-    }
-
-    fn num_string(&mut self, prefix: &str) -> Result<(Self::Num, Parts), Error> {
-        let mut num = Default::default();
-        let parts = self.num_bytes(&mut num, prefix.as_bytes())?;
+    fn num_string(&mut self, prefix: &'static str) -> Result<(Self::Num, Parts), Error> {
+        let mut num = prefix.as_bytes();
+        let parts = self.num_bytes(&mut num)?;
         // SAFETY: conversion to UTF-8 always succeeds because
         // lex_number validates everything it writes to num
         Ok((core::str::from_utf8(num).unwrap(), parts))
@@ -187,67 +129,12 @@ impl<'a> LexWrite for crate::SliceLexer<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl<E, I: Iterator<Item = Result<u8, E>>> crate::IterLexer<E, I> {
-    fn digits(&mut self, num: &mut <Self as Write>::Bytes) -> Result<(), Error> {
-        let mut some_digit = false;
-        while let Some(digit @ (b'0'..=b'9')) = self.peek_next() {
-            some_digit = true;
-            num.push(digit);
-            self.take_next();
-        }
-        if some_digit && self.error.is_none() {
-            Ok(())
-        } else {
-            Err(Error::ExpectedDigit)
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
 impl<E, I: Iterator<Item = Result<u8, E>>> LexWrite for crate::IterLexer<E, I> {
     type Num = alloc::string::String;
 
-    fn num_bytes(&mut self, num: &mut Self::Bytes, prefix: &[u8]) -> Result<Parts, Error> {
-        num.extend(prefix);
-        let mut parts = Parts::default();
-
-        if self.peek_next() == Some(b'0') {
-            num.push(b'0');
-            self.take_next();
-        } else {
-            self.digits(num)?;
-        }
-
-        loop {
-            match self.peek_next() {
-                Some(b'.') if parts.dot.is_none() && parts.exp.is_none() => {
-                    parts.dot = Some(NonZeroUsize::new(num.len()).unwrap());
-                    num.push(b'.');
-                    self.take_next();
-
-                    self.digits(num)?;
-                }
-
-                Some(e @ (b'e' | b'E')) if parts.exp.is_none() => {
-                    parts.exp = Some(NonZeroUsize::new(num.len()).unwrap());
-                    num.push(e);
-                    self.take_next();
-
-                    if let Some(sign @ (b'+' | b'-')) = self.peek_next() {
-                        num.push(sign);
-                        self.take_next();
-                    }
-
-                    self.digits(num)?;
-                }
-                _ => return Ok(parts),
-            }
-        }
-    }
-
-    fn num_string(&mut self, prefix: &str) -> Result<(Self::Num, Parts), Error> {
-        let mut num = Default::default();
-        let parts = self.num_bytes(&mut num, prefix.as_bytes())?;
+    fn num_string(&mut self, prefix: &'static str) -> Result<(Self::Num, Parts), Error> {
+        let mut num = prefix.into();
+        let parts = self.num_bytes(&mut num)?;
         // SAFETY: conversion to UTF-8 always succeeds because
         // lex_number validates everything it writes to num
         Ok((alloc::string::String::from_utf8(num).unwrap(), parts))

--- a/src/num.rs
+++ b/src/num.rs
@@ -4,10 +4,10 @@
 //! [`Lex::num_ignore`] and
 //! [`LexWrite::num_string`],
 //! accept numbers corresponding to the regex
-//! `\d+(\.\d+)?([eE]\d+)?`.
+//! `\d+(\.\d+)?([eE][+-]?\d+)?`.
 //! This is strictly more general than the JSON specification,
 //! which specifies numbers as
-//! `(0|[1-9]\d*)(\.\d+)?([eE]\d+)?`.
+//! `(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?`.
 //! That excludes numbers like `007`, which are accepted by the former regex.
 //!
 //! If you require stricter conformance to JSON numbers,
@@ -90,6 +90,7 @@ impl Parts {
                 self.exp = Some(len);
                 false
             }
+            b'+' | b'-' if self.exp.map(|i| i + 1) == Some(len) => false,
             _ => true,
         }
     }

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,10 +1,10 @@
-//! Positive numbers.
+//! Numbers.
 //!
 //! Conforming to the JSON specification, the lexers in this modules, in particular
 //! [`Lex::num_ignore`] and
 //! [`LexWrite::num_string`],
 //! accept numbers corresponding to the regex
-//! `(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?`.
+//! `-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?`.
 //!
 //! This leads numbers like `007` to be lexed as three separate numbers;
 //! `0`, `0`, and `7`.
@@ -14,6 +14,9 @@
 //!
 //! To prevent such behaviour, verify that numbers are not followed by a digit,
 //! e.g. with [`crate::Read::peek_next`].
+//! Alternatively, you can also instruct the number lexers to accept
+//! more liberal formats that do not have the problem illustrated here.
+//! See [`LexWrite::num_bytes_with`] for an example.
 use crate::{Read, Write};
 use core::fmt::{self, Display};
 /// Number lexing error.
@@ -37,98 +40,152 @@ impl Display for Error {
     }
 }
 
-/// Positions of various parts in the string representation of a number.
+/// Parts of a number.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Parts {
-    /// position of leading zero (`0`)
-    pub zero: Option<usize>,
-    /// position of the dot (`.`)
-    pub dot: Option<usize>,
-    /// position of the exponent character (`e`/`E`)
-    pub exp: Option<usize>,
+    /// leading zero (`0`)
+    pub zero: bool,
+    /// dot (`.`)
+    pub dot: bool,
+    /// exponent character (`e`/`E`)
+    pub exp: bool,
+}
+
+/// Positions of various parts in the string representation of a number.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Num<R = u8> {
+    read: R,
+    parts: Parts,
+}
+
+impl Num {
+    /// Parse numbers starting with `[+-]?\d+`.
+    pub fn signed_digits() -> Self {
+        Self::default().map_read(|_| b'e')
+    }
+
+    /// Parse numbers starting with `\d+`.
+    pub fn unsigned_digits() -> Self {
+        Self::default().map_read(|_| b'.')
+    }
+
+    /// Returns whether the next character `c` is part of the current number.
+    fn num_part(&mut self, c: u8) -> bool {
+        let Parts { zero, dot, exp } = &mut self.parts;
+        match (self.read, c) {
+            (0, b'-') => (),
+            (0 | b'-', b'0') if !*dot && !*exp => *zero = true,
+            (_, b'0'..=b'9') if !*zero || *dot || *exp => (),
+            (b'0'..=b'9', b'.') if !*dot && !*exp => *dot = true,
+            (b'0'..=b'9', b'e' | b'E') if !*exp => *exp = true,
+            (b'e' | b'E', b'+' | b'-') => (),
+            _ => return false,
+        };
+        self.read = c;
+        true
+    }
+
+    /// Return the [`Parts`] of the number if it is valid.
+    pub fn validate(self) -> Result<Parts, Error> {
+        self.read
+            .is_ascii_digit()
+            .then(|| self.parts)
+            .ok_or(Error::ExpectedDigit)
+    }
+}
+
+impl<R> Num<R> {
+    /// Return the contents and the [`Parts`] of the number, even if it is invalid.
+    ///
+    /// Because number lexing does not fail,
+    /// this function can return contents that are not numbers, such as
+    /// `""` and `"1."`.
+    ///
+    /// This can be useful if you wish to parse supersets of JSON,
+    /// where you want to accept things like `"+Infinity"` as a number.
+    pub fn unvalidated(self) -> (R, Parts) {
+        (self.read, self.parts)
+    }
+
+    fn map_read<R2>(self, f: impl FnOnce(R) -> R2) -> Num<R2> {
+        let read = f(self.read);
+        let parts = self.parts;
+        Num { read, parts }
+    }
 }
 
 impl Parts {
     /// Return true if the number contains neither a dot not an exponent.
     pub fn is_int(&self) -> bool {
-        self.dot.is_none() && self.exp.is_none()
+        !self.dot && !self.exp
+    }
+}
+
+impl<B: core::convert::AsRef<[u8]>> Num<B> {
+    /// Return the contents and the [`Parts`] of the number if it is valid.
+    pub fn validated(self) -> Result<(B, Parts), Error> {
+        let Self { read, parts } = self;
+        let valid = read.as_ref().last().map_or(false, u8::is_ascii_digit);
+        valid.then(|| (read, parts)).ok_or(Error::ExpectedDigit)
     }
 }
 
 /// Number lexing, ignoring the number.
 pub trait Lex: Read {
-    /// Lex a number and ignore its contents, saving only its parts.
-    fn num_ignore(&mut self) -> Result<Parts, Error> {
-        let mut parts = Parts::default();
-        let mut len = 0;
-        let mut prev = None;
-        self.skip_until(|c| {
-            !parts.num_part(len, prev, c) || {
-                len += 1;
-                prev = Some(c);
-                false
-            }
-        });
-        let valid = prev.as_ref().map_or(false, u8::is_ascii_digit);
-        valid.then(|| parts).ok_or(Error::ExpectedDigit)
+    /// Lex a number without saving its contents.
+    fn num_ignore(&mut self) -> Num {
+        self.num_ignore_with(Num::default())
+    }
+
+    /// Lex a number without saving its contents, using an initial number state.
+    fn num_ignore_with(&mut self, mut num: Num) -> Num {
+        self.skip_until(|c| !num.num_part(c));
+        num
     }
 }
 
 impl<T> Lex for T where T: Read {}
 
-impl Parts {
-    /// Returns whether the next character `c` is part of the current number.
-    fn num_part(&mut self, len: usize, prev: Option<u8>, c: u8) -> bool {
-        let Self { zero, exp, dot } = self;
-        match (prev, c) {
-            (None, b'0') => *zero = Some(len),
-            (_, b'0'..=b'9') => return zero.is_none() || dot.or(*exp).is_some(),
-            (Some(b'0'..=b'9'), b'.') if dot.or(*exp).is_none() => *dot = Some(len),
-            (Some(b'0'..=b'9'), b'e' | b'E') if exp.is_none() => *exp = Some(len),
-            (Some(b'e' | b'E'), b'+' | b'-') => return true,
-            _ => return false,
-        };
-        true
-    }
-}
-
 /// Number lexing, keeping the number.
 pub trait LexWrite: Lex + Write {
     /// String type to save numbers as.
-    type Num: core::ops::Deref<Target = str>;
+    type Num: core::ops::Deref<Target = str> + core::convert::AsRef<[u8]>;
 
-    /// Lex a number, append it to `num`, and save its parts.
-    ///
-    /// `num` must be a suffix of the previously consumed input.
-    /// Normally, you pass `b"-"` as prefix if you read "-" just before.
-    /// This allows you to include "-" in the bytes without allocation.
-    fn num_bytes(&mut self, num: &mut Self::Bytes) -> Result<Parts, Error> {
-        let mut parts = Parts::default();
-        let mut prev = None;
-        self.append_until(num, |b, c| {
-            !parts.num_part(b.len(), prev, c) || {
-                prev = Some(c);
-                false
-            }
-        });
-        let valid = prev.as_ref().map_or(false, u8::is_ascii_digit);
-        valid.then(|| parts).ok_or(Error::ExpectedDigit)
+    /// Write a number to bytes.
+    fn num_bytes(&mut self) -> Num<Self::Bytes> {
+        self.num_bytes_with(Num::default())
     }
 
-    /// Write a prefix and a number to a string and save its parts.
-    fn num_string(&mut self, prefix: &str) -> Result<(Self::Num, Parts), Error>;
+    /// Write a number to bytes, using an initial number state.
+    ///
+    /// The initial number state allows you to lex number formats that
+    /// diverge from the JSON specification.
+    /// For example, pass [`Num::signed_digits`] to lex
+    /// numbers starting with a `+` or `-` sign followed by
+    /// an arbitrary sequence of digits.
+    fn num_bytes_with(&mut self, mut num: Num) -> Num<Self::Bytes> {
+        let mut read = Default::default();
+        self.write_until(&mut read, |c| !num.num_part(c));
+        num.map_read(|_| read)
+    }
+
+    /// Write a number to a string.
+    fn num_string(&mut self) -> Num<Self::Num> {
+        self.num_string_with(Num::default())
+    }
+
+    /// Write a number to a string, using an initial number state.
+    fn num_string_with(&mut self, num: Num) -> Num<Self::Num>;
 }
 
 impl<'a> LexWrite for crate::SliceLexer<'a> {
     type Num = &'a str;
 
-    fn num_string(&mut self, prefix: &str) -> Result<(Self::Num, Parts), Error> {
-        let mut num = &self.whole[self.offset() - prefix.as_bytes().len()..self.offset()];
-        debug_assert_eq!(num, prefix.as_bytes());
-        let parts = self.num_bytes(&mut num)?;
+    fn num_string_with(&mut self, num: Num) -> Num<Self::Num> {
         // SAFETY: conversion to UTF-8 always succeeds because
-        // lex_number validates everything it writes to num
-        Ok((core::str::from_utf8(num).unwrap(), parts))
+        // num_bytes validates everything it writes to num
+        self.num_bytes_with(num)
+            .map_read(|read| core::str::from_utf8(read).unwrap())
     }
 }
 
@@ -136,11 +193,10 @@ impl<'a> LexWrite for crate::SliceLexer<'a> {
 impl<E, I: Iterator<Item = Result<u8, E>>> LexWrite for crate::IterLexer<E, I> {
     type Num = alloc::string::String;
 
-    fn num_string(&mut self, prefix: &str) -> Result<(Self::Num, Parts), Error> {
-        let mut num = prefix.into();
-        let parts = self.num_bytes(&mut num)?;
+    fn num_string_with(&mut self, num: Num) -> Num<Self::Num> {
         // SAFETY: conversion to UTF-8 always succeeds because
-        // lex_number validates everything it writes to num
-        Ok((alloc::string::String::from_utf8(num).unwrap(), parts))
+        // num_bytes validates everything it writes to num
+        self.num_bytes_with(num)
+            .map_read(|read| alloc::string::String::from_utf8(read).unwrap())
     }
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -18,7 +18,8 @@
 //! more liberal formats that do not have the problem illustrated here.
 //! See [`LexWrite::num_bytes_with`] for an example.
 use crate::{Read, Write};
-use core::fmt::{self, Display};
+use core::{convert::AsRef, fmt};
+
 /// Number lexing error.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -32,7 +33,7 @@ pub enum Error {
     ExpectedDigit,
 }
 
-impl Display for Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::ExpectedDigit => "expected digit".fmt(f),
@@ -121,7 +122,7 @@ impl Parts {
     }
 }
 
-impl<B: core::convert::AsRef<[u8]>> Num<B> {
+impl<B: AsRef<[u8]>> Num<B> {
     /// Return the contents and the [`Parts`] of the number if it is valid.
     pub fn validated(self) -> Result<(B, Parts), Error> {
         let Self { read, parts } = self;
@@ -149,7 +150,7 @@ impl<T> Lex for T where T: Read {}
 /// Number lexing, keeping the number.
 pub trait LexWrite: Lex + Write {
     /// String type to save numbers as.
-    type Num: core::ops::Deref<Target = str> + core::convert::AsRef<[u8]>;
+    type Num: AsRef<str> + AsRef<[u8]>;
 
     /// Write a number to bytes.
     fn num_bytes(&mut self) -> Num<Self::Bytes> {

--- a/src/num.rs
+++ b/src/num.rs
@@ -52,7 +52,25 @@ pub struct Parts {
     pub exp: bool,
 }
 
-/// Positions of various parts in the string representation of a number.
+/// Read character(s) and parts of a number prefix.
+///
+/// The type [`Num`] stores the number lexer state.
+/// Functions like
+/// [`LexWrite::num_bytes`] or
+/// [`LexWrite::num_string`]
+/// return the string representation `R` of the number prefix via [`Num<R>`].
+///
+/// JSON numbers start with a string corresponding to the regex
+/// `-?(0|[1-9]\d*)`.
+/// By initialising the number lexers in this module with a custom lexer state,
+/// such as [`LexWrite::num_string_with`] with [`Num::signed_digits`],
+/// you can lex numbers that
+/// start with strings corresponding to different regexes.
+///
+/// This type does not only store valid numbers,
+/// but more generally valid number _prefixes_, such as `"1."`.
+/// Use [`Num::validated`] or [`Num::validate`] to check whether
+/// a number prefix is actually a valid JSON number.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Num<R = u8> {
     read: R,
@@ -138,7 +156,7 @@ pub trait Lex: Read {
         self.num_ignore_with(Num::default())
     }
 
-    /// Lex a number without saving its contents, using an initial number state.
+    /// Lex a number without saving its contents, using an initial lexer state.
     fn num_ignore_with(&mut self, mut num: Num) -> Num {
         self.skip_until(|c| !num.num_part(c));
         num
@@ -157,7 +175,7 @@ pub trait LexWrite: Lex + Write {
         self.num_bytes_with(Num::default())
     }
 
-    /// Write a number to bytes, using an initial number state.
+    /// Write a number to bytes, using an initial lexer state.
     ///
     /// The initial number state allows you to lex number formats that
     /// diverge from the JSON specification.
@@ -175,7 +193,7 @@ pub trait LexWrite: Lex + Write {
         self.num_string_with(Num::default())
     }
 
-    /// Write a number to a string, using an initial number state.
+    /// Write a number to a string, using an initial lexer state.
     fn num_string_with(&mut self, num: Num) -> Num<Self::Num>;
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -51,9 +51,10 @@ impl<'a> Read for crate::SliceLexer<'a> {
         }
     }
 
-    fn skip_until(&mut self, stop: impl FnMut(u8) -> bool) {
-        use crate::Write;
-        self.write_until(&mut &[][..], stop)
+    fn skip_until(&mut self, mut stop: impl FnMut(u8) -> bool) {
+        while let Some((_, tl)) = self.slice.split_first().filter(|(hd, _)| !stop(**hd)) {
+            self.slice = tl
+        }
     }
 
     fn take_next(&mut self) -> Option<u8> {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -78,7 +78,7 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
     where
         V: Visitor<'de>,
     {
-        let num = |lexer: &mut L, visitor: V, prefix: &str| {
+        let num = |lexer: &mut L, visitor: V, prefix: &'static str| {
             let (n, parts) = lexer.num_string(prefix).map_err(Num)?;
             match (parts.is_int(), prefix) {
                 (true, "-") => visitor.visit_i64(parse_number(&n)?),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -78,7 +78,7 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
     where
         V: Visitor<'de>,
     {
-        let num = |lexer: &mut L, visitor: V, prefix: &'static str| {
+        let num = |lexer: &mut L, visitor: V, prefix: &str| {
             let (n, parts) = lexer.num_string(prefix).map_err(Num)?;
             match (parts.is_int(), prefix) {
                 (true, "-") => visitor.visit_i64(parse_number(&n)?),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -63,7 +63,7 @@ macro_rules! deserialize_number {
         fn $deserialize<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
             use crate::Error::Num;
             let (n, _parts) = self.lexer.num_string().validated().map_err(Num)?;
-            visitor.$visit(parse_number(&n)?)
+            visitor.$visit(parse_number(n.as_ref())?)
         }
     };
 }
@@ -77,10 +77,11 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
     {
         let num = |lexer: &mut L, visitor: V| {
             let (n, parts) = lexer.num_string().validated().map_err(Num)?;
+            let n: &str = n.as_ref();
             match (n.starts_with("-"), parts.is_int()) {
-                (true, true) => visitor.visit_i64(parse_number(&n)?),
-                (false, true) => visitor.visit_u64(parse_number(&n)?),
-                (_, false) => visitor.visit_f64(parse_number(&n)?),
+                (true, true) => visitor.visit_i64(parse_number(n)?),
+                (false, true) => visitor.visit_u64(parse_number(n)?),
+                (_, false) => visitor.visit_f64(parse_number(n)?),
             }
         };
 
@@ -91,7 +92,7 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
                 Some(b) => visitor.visit_bool(b),
             },
             b'0'..=b'9' | b'-' => num(self.lexer, visitor),
-            b'"' => visitor.visit_str(&self.lexer.discarded().str_string().map_err(Str)?),
+            b'"' => visitor.visit_str(self.lexer.discarded().str_string().map_err(Str)?.as_ref()),
             b'[' => visitor.visit_seq(CommaSeparated::new(self.lexer.discarded())),
             b'{' => visitor.visit_map(CommaSeparated::new(self.lexer.discarded())),
             _ => Err(Expect::Value)?,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -61,11 +61,8 @@ fn parse_number<T: core::str::FromStr>(n: &str) -> Result<T> {
 macro_rules! deserialize_number {
     ($deserialize:ident, $visit:ident) => {
         fn $deserialize<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-            let (prefix, lexer) = match self.next {
-                b'-' => ("-", self.lexer.discarded()),
-                _ => ("", self.lexer),
-            };
-            let (n, _parts) = lexer.num_string(prefix).map_err(crate::Error::Num)?;
+            use crate::Error::Num;
+            let (n, _parts) = self.lexer.num_string().validated().map_err(Num)?;
             visitor.$visit(parse_number(&n)?)
         }
     };
@@ -78,12 +75,12 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
     where
         V: Visitor<'de>,
     {
-        let num = |lexer: &mut L, visitor: V, prefix: &str| {
-            let (n, parts) = lexer.num_string(prefix).map_err(Num)?;
-            match (parts.is_int(), prefix) {
-                (true, "-") => visitor.visit_i64(parse_number(&n)?),
-                (true, _) => visitor.visit_u64(parse_number(&n)?),
-                (false, _) => visitor.visit_f64(parse_number(&n)?),
+        let num = |lexer: &mut L, visitor: V| {
+            let (n, parts) = lexer.num_string().validated().map_err(Num)?;
+            match (n.starts_with("-"), parts.is_int()) {
+                (true, true) => visitor.visit_i64(parse_number(&n)?),
+                (false, true) => visitor.visit_u64(parse_number(&n)?),
+                (_, false) => visitor.visit_f64(parse_number(&n)?),
             }
         };
 
@@ -93,8 +90,7 @@ impl<'de, 'a, L: LexAlloc + 'de> de::Deserializer<'de> for TokenLexer<&'a mut L>
                 None => visitor.visit_unit(),
                 Some(b) => visitor.visit_bool(b),
             },
-            b'0'..=b'9' => num(self.lexer, visitor, ""),
-            b'-' => num(self.lexer.discarded(), visitor, "-"),
+            b'0'..=b'9' | b'-' => num(self.lexer, visitor),
             b'"' => visitor.visit_str(&self.lexer.discarded().str_string().map_err(Str)?),
             b'[' => visitor.visit_seq(CommaSeparated::new(self.lexer.discarded())),
             b'{' => visitor.visit_map(CommaSeparated::new(self.lexer.discarded())),

--- a/src/str.rs
+++ b/src/str.rs
@@ -180,7 +180,7 @@ pub trait LexWrite: escape::Lex + Read + Write {
     /// Read a string to bytes, copying escape sequences one-to-one.
     fn str_bytes(&mut self, bytes: &mut Self::Bytes) -> Result<(), Error> {
         let mut state = State::default();
-        self.write_until(bytes, |c| state.process(c));
+        self.write_until(bytes, |_, c| state.process(c));
         state.finish(|| self.take_next())
     }
 
@@ -196,7 +196,7 @@ pub trait LexWrite: escape::Lex + Read + Write {
         }
 
         let mut bytes = Self::Bytes::default();
-        self.write_until(&mut bytes, string_end);
+        self.write_until(&mut bytes, |_, c| string_end(c));
         on_string(&mut bytes, &mut out)?;
         match self.take_next().ok_or(Error::Eof)? {
             b'\\' => (),
@@ -206,7 +206,7 @@ pub trait LexWrite: escape::Lex + Read + Write {
         }
         loop {
             on_escape(self, &mut out)?;
-            self.write_until(&mut bytes, string_end);
+            self.write_until(&mut bytes, |_, c| string_end(c));
             on_string(&mut bytes, &mut out)?;
             match self.take_next().ok_or(Error::Eof)? {
                 b'\\' => continue,

--- a/src/str.rs
+++ b/src/str.rs
@@ -180,7 +180,7 @@ pub trait LexWrite: escape::Lex + Read + Write {
     /// Read a string to bytes, copying escape sequences one-to-one.
     fn str_bytes(&mut self, bytes: &mut Self::Bytes) -> Result<(), Error> {
         let mut state = State::default();
-        self.write_until(bytes, |_, c| state.process(c));
+        self.write_until(bytes, |c| state.process(c));
         state.finish(|| self.take_next())
     }
 
@@ -196,7 +196,7 @@ pub trait LexWrite: escape::Lex + Read + Write {
         }
 
         let mut bytes = Self::Bytes::default();
-        self.write_until(&mut bytes, |_, c| string_end(c));
+        self.write_until(&mut bytes, string_end);
         on_string(&mut bytes, &mut out)?;
         match self.take_next().ok_or(Error::Eof)? {
             b'\\' => (),
@@ -206,7 +206,7 @@ pub trait LexWrite: escape::Lex + Read + Write {
         }
         loop {
             on_escape(self, &mut out)?;
-            self.write_until(&mut bytes, |_, c| string_end(c));
+            self.write_until(&mut bytes, string_end);
             on_string(&mut bytes, &mut out)?;
             match self.take_next().ok_or(Error::Eof)? {
                 b'\\' => continue,

--- a/src/str.rs
+++ b/src/str.rs
@@ -28,8 +28,7 @@
 
 use crate::escape;
 use crate::{Read, Write};
-use core::fmt;
-use core::ops::Deref;
+use core::{convert::AsRef, fmt};
 
 /// Wrapper type to facilitate printing strings as JSON.
 pub struct Display<Str>(Str);
@@ -41,10 +40,10 @@ impl<Str> Display<Str> {
     }
 }
 
-impl<Str: Deref<Target = str>> fmt::Display for Display<Str> {
+impl<Str: AsRef<str>> fmt::Display for Display<Str> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         '"'.fmt(f)?;
-        for c in self.0.chars() {
+        for c in self.0.as_ref().chars() {
             match c {
                 '\\' | '"' | '\n' | '\r' | '\t' => c.escape_default().try_for_each(|c| c.fmt(f)),
                 c if (c as u32) < 20 => write!(f, "\\u{:04x}", c as u16),
@@ -224,7 +223,7 @@ impl<T> LexWrite for T where T: Read + Write {}
 /// allocates when lexing from slices that contain escape sequences.
 pub trait LexAlloc: LexWrite {
     /// The type of string that we are lexing into.
-    type Str: Deref<Target = str>;
+    type Str: AsRef<str>;
 
     /// Lex a JSON string to a Rust string.
     fn str_string(&mut self) -> Result<Self::Str, Error>;

--- a/src/value.rs
+++ b/src/value.rs
@@ -80,8 +80,7 @@ fn parse<L: LexAlloc>(
     let nob = |o: Option<bool>| o.map(Value::Bool).unwrap_or(Value::Null);
     match next {
         b'a'..=b'z' => Ok(lexer.null_or_bool().map(nob).ok_or(Expect::Value)?),
-        b'-' => Ok(Value::Number(lexer.discarded().num_string("-")?)),
-        b'0'..=b'9' => Ok(Value::Number(lexer.num_string("")?)),
+        b'0'..=b'9' | b'-' => Ok(Value::Number(lexer.num_string().validated()?)),
         b'"' => Ok(Value::String(lexer.discarded().str_string()?)),
         b'[' => Ok(Value::Array({
             let mut arr = Vec::new();

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,8 +3,7 @@
 use crate::token::Expect;
 use crate::{num, str, Error, LexAlloc};
 use alloc::vec::Vec;
-use core::fmt;
-use core::ops::Deref;
+use core::{convert::AsRef, fmt};
 
 /// JSON value.
 #[derive(Debug)]
@@ -43,14 +42,14 @@ impl<NumL: PartialEq<NumR>, NumR, StrL: PartialEq<StrR>, StrR> PartialEq<Value<N
     }
 }
 
-impl<Num: Deref<Target = str>, Str: Deref<Target = str>> fmt::Display for Value<Num, Str> {
+impl<Num: AsRef<str>, Str: AsRef<str>> fmt::Display for Value<Num, Str> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Value::*;
         match self {
             Null => "null".fmt(f),
             Bool(b) => b.fmt(f),
-            Number((n, _)) => n.fmt(f),
-            String(s) => str::Display::new(&**s).fmt(f),
+            Number((n, _)) => n.as_ref().fmt(f),
+            String(s) => str::Display::new(s.as_ref()).fmt(f),
             Array(a) => {
                 "[".fmt(f)?;
                 let mut iter = a.iter();
@@ -60,7 +59,7 @@ impl<Num: Deref<Target = str>, Str: Deref<Target = str>> fmt::Display for Value<
             }
             Object(o) => {
                 "{".fmt(f)?;
-                let mut iter = o.iter().map(|(k, v)| (str::Display::new(&**k), v));
+                let mut iter = o.iter().map(|(k, v)| (str::Display::new(k.as_ref()), v));
                 iter.next()
                     .iter()
                     .try_for_each(|(k, v)| write!(f, "{}:{}", k, v))?;

--- a/src/write.rs
+++ b/src/write.rs
@@ -37,9 +37,10 @@ impl<'a> Write for crate::SliceLexer<'a> {
         let prefix = bytes.len();
         // rewind by prefix length
         self.slice = &self.whole[self.offset() - prefix..];
-        let pos = (prefix..self.slice.len())
-            .position(|l| stop(&self.slice[..l], self.slice[l]))
-            .unwrap_or(self.slice.len());
+        let mut iter = self.slice.iter().enumerate().skip(prefix);
+        let pos = iter
+            .find(|(i, c)| stop(&self.slice[..*i], **c))
+            .map_or(self.slice.len(), |(i, _c)| i);
         *bytes = &self.slice[..pos];
         self.slice = &self.slice[pos..]
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -13,26 +13,40 @@ pub trait Write {
     /// ~~~
     /// fn test<L: hifijson::Write>(lexer: &mut L) {
     ///     let mut bytes = L::Bytes::default();
-    ///     lexer.write_until(&mut bytes, |c| c == b' ');
+    ///     lexer.write_until(&mut bytes, |_, c| c == b' ');
     ///     assert_eq!(&*bytes, b"Hello");
-    ///     lexer.write_until(&mut bytes, |_| false);
+    ///     lexer.write_until(&mut bytes, |_, _| false);
     ///     assert_eq!(&*bytes, b" World");
     /// }
     /// let s = b"Hello World";
     /// test(&mut hifijson::SliceLexer::new(s));
     /// test(&mut hifijson::IterLexer::new(s.iter().copied().map(Ok::<_, ()>)));
     /// ~~~
-    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(u8) -> bool);
+    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool);
+
+    /// Append input to `bytes` until `stop` yields true.
+    ///
+    /// This assumes that `bytes` is a suffix of the previously consumed input.
+    fn append_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool);
 }
 
 impl<'a> Write for crate::SliceLexer<'a> {
     type Bytes = &'a [u8];
 
-    fn write_until(&mut self, bytes: &mut &'a [u8], mut stop: impl FnMut(u8) -> bool) {
-        let pos = self.slice.iter().position(|c| stop(*c));
-        let pos = pos.unwrap_or(self.slice.len());
+    fn append_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(&[u8], u8) -> bool) {
+        let prefix = bytes.len();
+        // rewind by prefix length
+        self.slice = &self.whole[self.offset() - prefix..];
+        let pos = (prefix..self.slice.len())
+            .position(|l| stop(&self.slice[..l], self.slice[l]))
+            .unwrap_or(self.slice.len());
         *bytes = &self.slice[..pos];
         self.slice = &self.slice[pos..]
+    }
+
+    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool) {
+        *bytes = &[];
+        self.append_until(bytes, stop)
     }
 }
 
@@ -40,11 +54,15 @@ impl<'a> Write for crate::SliceLexer<'a> {
 impl<E, I: Iterator<Item = Result<u8, E>>> Write for crate::IterLexer<E, I> {
     type Bytes = alloc::vec::Vec<u8>;
 
-    fn write_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(u8) -> bool) {
-        use crate::Read;
+    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool) {
         bytes.clear();
+        self.append_until(bytes, stop)
+    }
+
+    fn append_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(&[u8], u8) -> bool) {
+        use crate::Read;
         while let Some(c) = self.peek_next() {
-            if stop(c) {
+            if stop(bytes, c) {
                 return;
             } else {
                 self.take_next();

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,7 +4,7 @@
 /// without allocating when the input is a slice.
 pub trait Write {
     /// Type of bytes to write to.
-    type Bytes: core::ops::Deref<Target = [u8]> + Default;
+    type Bytes: core::ops::Deref<Target = [u8]> + core::convert::AsRef<[u8]> + Default;
 
     /// Write input to `bytes` until `stop` yields true.
     ///
@@ -15,45 +15,26 @@ pub trait Write {
     /// ~~~
     /// fn test<L: hifijson::Write>(lexer: &mut L) {
     ///     let mut bytes = L::Bytes::default();
-    ///     lexer.write_until(&mut bytes, |_, c| c == b' ');
+    ///     lexer.write_until(&mut bytes, |c| c == b' ');
     ///     assert_eq!(&*bytes, b"Hello");
-    ///     lexer.write_until(&mut bytes, |_, _| false);
+    ///     lexer.write_until(&mut bytes, |_| false);
     ///     assert_eq!(&*bytes, b" World");
     /// }
     /// let s = b"Hello World";
     /// test(&mut hifijson::SliceLexer::new(s));
     /// test(&mut hifijson::IterLexer::new(s.iter().copied().map(Ok::<_, ()>)));
     /// ~~~
-    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool);
-
-    /// Append input to `bytes` until `stop` yields true.
-    ///
-    /// This assumes that `bytes` is a suffix of the previously consumed input.
-    fn append_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool);
+    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(u8) -> bool);
 }
 
 impl<'a> Write for crate::SliceLexer<'a> {
     type Bytes = &'a [u8];
 
-    fn append_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(&[u8], u8) -> bool) {
-        // in my end is your beginning
-        debug_assert_eq!(
-            bytes.as_ptr() as usize + bytes.len(),
-            self.slice.as_ptr() as usize
-        );
-        // rewind by prefix length
-        self.slice = &self.whole[self.offset() - bytes.len()..];
-        let mut iter = self.slice.iter().enumerate().skip(bytes.len());
-        let pos = iter
-            .find(|(i, c)| stop(&self.slice[..*i], **c))
-            .map_or(self.slice.len(), |(i, _c)| i);
+    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(u8) -> bool) {
+        let pos = self.slice.iter().cloned().position(stop);
+        let pos = pos.unwrap_or(self.slice.len());
         *bytes = &self.slice[..pos];
         self.slice = &self.slice[pos..]
-    }
-
-    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool) {
-        *bytes = &self.slice[..0];
-        self.append_until(bytes, stop)
     }
 }
 
@@ -61,15 +42,11 @@ impl<'a> Write for crate::SliceLexer<'a> {
 impl<E, I: Iterator<Item = Result<u8, E>>> Write for crate::IterLexer<E, I> {
     type Bytes = alloc::vec::Vec<u8>;
 
-    fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(&[u8], u8) -> bool) {
-        bytes.clear();
-        self.append_until(bytes, stop)
-    }
-
-    fn append_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(&[u8], u8) -> bool) {
+    fn write_until(&mut self, bytes: &mut Self::Bytes, mut stop: impl FnMut(u8) -> bool) {
         use crate::Read;
+        bytes.clear();
         while let Some(c) = self.peek_next() {
-            if stop(bytes, c) {
+            if stop(c) {
                 return;
             } else {
                 self.take_next();

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,7 +4,7 @@
 /// without allocating when the input is a slice.
 pub trait Write {
     /// Type of bytes to write to.
-    type Bytes: core::ops::Deref<Target = [u8]> + core::convert::AsRef<[u8]> + Default;
+    type Bytes: core::convert::AsRef<[u8]> + Default;
 
     /// Write input to `bytes` until `stop` yields true.
     ///
@@ -16,9 +16,9 @@ pub trait Write {
     /// fn test<L: hifijson::Write>(lexer: &mut L) {
     ///     let mut bytes = L::Bytes::default();
     ///     lexer.write_until(&mut bytes, |c| c == b' ');
-    ///     assert_eq!(&*bytes, b"Hello");
+    ///     assert_eq!(bytes.as_ref(), b"Hello");
     ///     lexer.write_until(&mut bytes, |_| false);
-    ///     assert_eq!(&*bytes, b" World");
+    ///     assert_eq!(bytes.as_ref(), b" World");
     /// }
     /// let s = b"Hello World";
     /// test(&mut hifijson::SliceLexer::new(s));

--- a/src/write.rs
+++ b/src/write.rs
@@ -31,7 +31,7 @@ impl<'a> Write for crate::SliceLexer<'a> {
     type Bytes = &'a [u8];
 
     fn write_until(&mut self, bytes: &mut Self::Bytes, stop: impl FnMut(u8) -> bool) {
-        let pos = self.slice.iter().cloned().position(stop);
+        let pos = self.slice.iter().copied().position(stop);
         let pos = pos.unwrap_or(self.slice.len());
         *bytes = &self.slice[..pos];
         self.slice = &self.slice[pos..]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,3 @@
-use core::num::NonZeroUsize;
 use hifijson::token::Lex;
 use hifijson::value::{self, Value};
 use hifijson::{escape, ignore, num, str, Error, Expect, IterLexer, LexAlloc, SliceLexer};
@@ -8,8 +7,6 @@ fn boole<Num, Str>(b: bool) -> Value<Num, Str> {
 }
 
 fn num<Num, Str>(n: Num, dot: Option<usize>, exp: Option<usize>) -> Value<Num, Str> {
-    let dot = dot.map(|i| NonZeroUsize::new(i).unwrap());
-    let exp = exp.map(|i| NonZeroUsize::new(i).unwrap());
     Value::Number((n, num::Parts { dot, exp }))
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -121,9 +121,14 @@ fn numbers() -> Result<(), Error> {
     parses_to(b"299e6", num("299e6", None, Some(3)))?;
     // now a bit more precise
     parses_to(b"299.792e6", num("299.792e6", Some(3), Some(7)))?;
-    parses_to(b"-1.2e3", num("-1.2e3", Some(2), Some(4)))?;
+    parses_to(b"-1.2e+3", num("-1.2e+3", Some(2), Some(4)))?;
+    parses_to(b"-1.2e-3", num("-1.2e-3", Some(2), Some(4)))?;
 
     fails_with(b"-", num::Error::ExpectedDigit.into());
+    fails_with(b"1.", num::Error::ExpectedDigit.into());
+    fails_with(b"1e", num::Error::ExpectedDigit.into());
+    fails_with(b"1e+", num::Error::ExpectedDigit.into());
+    fails_with(b"1e-", num::Error::ExpectedDigit.into());
 
     Ok(())
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,12 +7,10 @@ fn boole<Num, Str>(b: bool) -> Value<Num, Str> {
 }
 
 fn num<Str>(n: &str) -> Value<&str, Str> {
-    let pos_zero = n.starts_with("0").then_some(0);
-    let neg_zero = n.starts_with("-0").then_some(1);
     let parts = num::Parts {
-        zero: pos_zero.or(neg_zero),
-        dot: n.find('.'),
-        exp: n.find(['e', 'E']),
+        zero: n.starts_with("0") || n.starts_with("-0"),
+        dot: n.contains('.'),
+        exp: n.contains(['e', 'E']),
     };
     Value::Number((n, parts))
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -62,7 +62,7 @@ fn parse_binary_string<L: LexAlloc>(next: u8, lexer: &mut L) -> Result<Vec<u8>, 
         Err(Error::Token(Expect::String))?
     }
     let on_string = |bytes: &mut L::Bytes, out: &mut Vec<u8>| {
-        out.extend_from_slice(bytes);
+        out.extend_from_slice(bytes.as_ref());
         Ok(())
     };
     let s = lexer.str_fold(Vec::new(), on_string, |lexer, out| {


### PR DESCRIPTION
This simplifies number lexing and documents it better, thus clarifying potentially confusing cases as brought up in #11.
It also allows for lexing numbers that start with different prefixes.

As breaking change, this removes `SliceLexer::offset()`, because it is not necessary anymore to store the whole slice, and thus the offset cannot be calculated anymore by `SliceLexer`.